### PR TITLE
Avoid tainting golden images during their build process

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,5 @@ buildkite_agent_name: "buildkite-agent"
 buildkite_agent_meta_data: "queue=default"
 buildkite_agent_meta_data_ec2_tags: "true"
 buildkite_agent_debug: "false"
+buildkite_agent_enabled: true
+buildkite_agent_state: "started"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,9 @@
             mode=0600
   notify:
     - Restart Buildkite
+
+- name: Configure Buildkite service state
+  service:
+    name: buildkite-agent
+    enabled: "{{ buildkite_agent_enabled }}"
+    state: "{{ buildkite_agent_state }}"


### PR DESCRIPTION
If the agent connects during the image-build process, it could become polluted by running builds. Keep it pristine.