### PR TITLE
Add Darwin platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Variable names below map to [the agent configuration documentation](https://buil
 - `buildkite_agent_git_clone_flags`
 - `buildkite_agent_git_clean_flags`
 - `buildkite_agent_no_pty`
-- `buildkite_agent_no_fingerprint_verification`
+- `buildkite_agent_no_ssh_keyscan`
 - `buildkite_agent_no_command_eval`
 - `buildkite_agent_no_plugins`
 - `buildkite_agent_no_color`

--- a/README.md
+++ b/README.md
@@ -19,13 +19,6 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 - `buildkite_agent_hooks_dir` - Path to where agent will look for hooks.
 - `buildkite_agent_plugins_dir` - Path to where agent will look for plugins.
 
-### Version-related
-
-- `buildkite_agent_allow_latest` - whether to allow the latest version to be installed, or instead use a specified version.
-  - **NOTE:** ignored, on Windows (no package manager install option).
-- `buildkite_agent_version` - the main semantic version number to install, when `buildkite_agent_allow_latest` is `False`.
-- `buildkite_agent_build_number` - the build number (ubuntu package name includes this).
-
 ### Configuration settings
 
 Variable names below map to [the agent configuration documentation](https://buildkite.com/docs/agent/v3/configuration#configuration-settings), with the same defaults, except where otherwise stated.
@@ -46,7 +39,16 @@ Variable names below map to [the agent configuration documentation](https://buil
 - `buildkite_agent_no_plugins`
 - `buildkite_agent_no_color`
 
-### Miscellaneous
+### Platform specific settings
+
+#### Debian
+
+- `buildkite_agent_allow_latest` - whether to allow the latest version to be installed, or instead use a specified version.
+  - **NOTE:** ignored, on Windows (no package manager install option).
+- `buildkite_agent_version` - the main semantic version number to install, when `buildkite_agent_allow_latest` is `False`.
+- `buildkite_agent_build_number` - the build number (ubuntu package name includes this).
+
+#### Windows
 
 - `buildkite_agent_nssm_version` - Which version of [NSSM] to use to manage the buildkite-agent process as a service.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Variable names below map to [the agent configuration documentation](https://buil
 
 - `buildkite_agent_nssm_version` - Which version of [NSSM] to use to manage the buildkite-agent process as a service.
 
+#### Darwin
+
+- `buildkite_agent_load_bash_profile` - Load `$HOME/.bash_profile` with buildkite agent environment hook. Ensures agent will load with bash environment.
+
 ## Example Playbook
 
 See the [examples](./examples/) directory.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Variable names below map to [the agent configuration documentation](https://buil
 - `buildkite_agent_git_clone_flags`
 - `buildkite_agent_git_clean_flags`
 - `buildkite_agent_no_pty`
-- `buildkite_agent_no_ssh_keyscan`
+- `buildkite_agent_no_fingerprint_verification`
 - `buildkite_agent_no_command_eval`
 - `buildkite_agent_no_plugins`
 - `buildkite_agent_no_color`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,13 @@
 ---
 # core
 buildkite_agent_conf_dir:
+  Darwin: "/usr/local/etc/buildkite-agent"
   Debian: "/etc/buildkite-agent"
   Windows: "c:/programdata/buildkite-agent"
 buildkite_agent_count: 1
 buildkite_agent_debug: "false"
 buildkite_agent_home_dir:
+  Darwin: "/usr/local/var/buildkite-agent"
   Debian: "/var/lib/buildkite-agent"
   Windows: "c:/users/buildkite-agent"
 buildkite_agent_token: ""
@@ -13,23 +15,22 @@ buildkite_agent_windows_grant_admin: False
 
 # paths config
 buildkite_agent_builds_dir:
+  Darwin: "{{ buildkite_agent_home_dir.Darwin }}/builds"
   Debian: "{{ buildkite_agent_home_dir.Debian }}/builds"
   Windows: "c:/b"  # long filenames will overflow
 buildkite_agent_hooks_dir:
+  Darwin: "{{ buildkite_agent_conf_dir.Darwin }}/hooks"
   Debian: "{{ buildkite_agent_home_dir.Debian }}/hooks"
   Windows: "{{ buildkite_agent_conf_dir.Windows }}/hooks"
 buildkite_agent_plugins_dir:
+  Darwin: "{{ buildkite_agent_home_dir.Darwin }}/plugins"
   Debian: "{{ buildkite_agent_home_dir.Debian }}/plugins"
   Windows: "{{ buildkite_agent_conf_dir.Windows }}/plugins"
-
-# version related
-buildkite_agent_allow_latest: yes
-buildkite_agent_version: "3.4.0"
-buildkite_agent_build_number: "2484"
 
 # configuration values, see https://buildkite.com/docs/agent/v3/configuration
 # note: the booleans are quoted otherwise they are rendered capitalised.
 buildkite_agent_bootstrap_script:
+  Darwin: "{{ buildkite_agent_conf_dir.Darwin }}/bootstrap.sh"
   Debian: "buildkite-agent bootstrap"
   Windows: "buildkite-agent bootstrap"
 buildkite_agent_git_clean_flags: "-fxdq"
@@ -38,8 +39,7 @@ buildkite_agent_no_color: "false"
 buildkite_agent_no_command_eval: "false"
 buildkite_agent_no_plugins: "false"
 buildkite_agent_no_pty: "false"
-buildkite_agent_no_ssh_keyscan: "false"
-buildkite_agent_platform: "amd64"
+buildkite_agent_no_fingerprint_verification: "true"
 buildkite_agent_priority: 1
 buildkite_agent_queue: "default"
 buildkite_agent_tags: []
@@ -48,5 +48,11 @@ buildkite_agent_tags_from_ec2_tags: "false"
 buildkite_agent_tags_from_gcp: "false"
 buildkite_agent_tags_from_host: "false"
 
-# miscellaneous
+# Debian options
+buildkite_agent_allow_latest: yes
+buildkite_agent_version: "3.4.0"
+buildkite_agent_build_number: "2484"
+
+# Windows options
 buildkite_agent_nssm_version: "2.24.101.20180116"
+buildkite_agent_platform: "amd64"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,3 +56,6 @@ buildkite_agent_build_number: "2484"
 # Windows options
 buildkite_agent_nssm_version: "2.24.101.20180116"
 buildkite_agent_platform: "amd64"
+
+# Darwin options
+buildkite_agent_load_bash_profile: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ buildkite_agent_no_color: "false"
 buildkite_agent_no_command_eval: "false"
 buildkite_agent_no_plugins: "false"
 buildkite_agent_no_pty: "false"
-buildkite_agent_no_fingerprint_verification: "true"
+buildkite_agent_no_ssh_keyscan: "false"
 buildkite_agent_priority: 1
 buildkite_agent_queue: "default"
 buildkite_agent_tags: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,11 @@
     name: buildkite-agent
     state: restarted
   when: ansible_os_family == "Windows"
+
+- name: Restart Buildkite Agent and Register for Login
+  command: /usr/local/bin/brew services restart buildkite/buildkite/buildkite-agent
+  when: ansible_os_family == "Darwin"
+
+- name: Start Buildkite Agent and Register for Login
+  command: /usr/local/bin/brew services start buildkite/buildkite/buildkite-agent
+  when: ansible_os_family == "Darwin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,8 +11,11 @@ galaxy_info:
     - name: Windows
       versions:
         - "2016"
+    - name: Darwin
   categories:
     - system
   galaxy_tags:
     - buildkite
+    - buidkite-agent
+    - agent
 dependencies: []

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -1,0 +1,28 @@
+---
+# https://buildkite.com/docs/agent/v3/osx
+# TODO:
+# * Conditionally upgrade when already present - `brew update && brew upgrade buildkite-agent`
+- homebrew_tap:
+    name: buildkite/buildkite
+    state: present
+
+- homebrew:
+    name: buildkite-agent
+    state: latest
+    update_homebrew: yes
+
+- name: Configure Buildkite
+  template:
+    src: "buildkite-agent.cfg.j2"
+    dest: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
+    mode: "0600"
+  notify:
+    - "Restart Buildkite Agent and Register for Login"
+
+- name: Set environment hook to load bash profile for test runs
+  template:
+    src: "buildkite-agent-hook-environment.sh"
+    dest: "{{ buildkite_agent_hooks_dir[ansible_os_family] }}/environment"
+    mode: "0600"
+  notify:
+    - "Restart Buildkite Agent and Register for Login"

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -24,5 +24,6 @@
     src: "buildkite-agent-hook-environment.sh"
     dest: "{{ buildkite_agent_hooks_dir[ansible_os_family] }}/environment"
     mode: "0600"
+  when: buildkite_agent_load_bash_profile == True
   notify:
     - "Restart Buildkite Agent and Register for Login"

--- a/templates/buildkite-agent-hook-environment.sh
+++ b/templates/buildkite-agent-hook-environment.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-source "$HOME/.bash_profile"
+[[ -f "$HOME/.bash_profile" ]] && source "$HOME/.bash_profile"

--- a/templates/buildkite-agent-hook-environment.sh
+++ b/templates/buildkite-agent-hook-environment.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-[[ -f "$HOME/.bash_profile" ]] && source "$HOME/.bash_profile"
+set -euo pipefail
+[[ -f "${HOME}/.bash_profile" ]] && source "${HOME}/.bash_profile"

--- a/templates/buildkite-agent-hook-environment.sh
+++ b/templates/buildkite-agent-hook-environment.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+source "$HOME/.bash_profile"

--- a/templates/buildkite-agent.cfg.j2
+++ b/templates/buildkite-agent.cfg.j2
@@ -45,8 +45,8 @@ git-clean-flags={{ buildkite_agent_git_clean_flags }}
 # Do not run jobs within a pseudo terminal
 no-pty={{ buildkite_agent_no_pty }}
 
-# Don't automatically verify SSH fingerprints
-no-automatic-ssh-fingerprint-verification=={{ buildkite_agent_no_fingerprint_verification }}
+# Don't automatically run ssh-keyscan before checkout
+no-ssh-keyscan={{ buildkite_agent_no_ssh_keyscan }}
 
 # Don't allow this agent to run arbitrary console commands
 no-command-eval={{ buildkite_agent_no_command_eval }}

--- a/templates/buildkite-agent.cfg.j2
+++ b/templates/buildkite-agent.cfg.j2
@@ -1,5 +1,5 @@
 # The token from your Buildkite "Agents" page
-token="{{ buildkite_agent_token }}"
+token="{{ buildkite_agent_token | mandatory }}"
 
 # The name of the agent
 name="%hostname-%n"
@@ -25,7 +25,7 @@ tags-from-host={{ buildkite_agent_tags_from_host }}
 # Path to a custom boostrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!
 # See https://buildkite.com/docs/agent/hooks
-bootstrap-script="{{ buildkite_agent_bootstrap_script[ansible_os_family] }}"
+# bootstrap-script="{{ buildkite_agent_bootstrap_script[ansible_os_family] }}" # Deprecated in latest buildkite version
 
 # Path to where the builds will run from
 build-path="{{ buildkite_agent_builds_dir[ansible_os_family] }}"
@@ -45,8 +45,8 @@ git-clean-flags={{ buildkite_agent_git_clean_flags }}
 # Do not run jobs within a pseudo terminal
 no-pty={{ buildkite_agent_no_pty }}
 
-# Don't automatically run ssh-keyscan before checkout
-no-ssh-keyscan={{ buildkite_agent_no_ssh_keyscan }}
+# Don't automatically verify SSH fingerprints
+no-automatic-ssh-fingerprint-verification=={{ buildkite_agent_no_fingerprint_verification }}
 
 # Don't allow this agent to run arbitrary console commands
 no-command-eval={{ buildkite_agent_no_command_eval }}

--- a/templates/buildkite-agent.cfg.j2
+++ b/templates/buildkite-agent.cfg.j2
@@ -1,5 +1,5 @@
 # The token from your Buildkite "Agents" page
-token="{{ buildkite_agent_token | mandatory }}"
+token="{{ buildkite_agent_token }}"
 
 # The name of the agent
 name="%hostname-%n"


### PR DESCRIPTION
We install buildkite agent on a suite of mac minis (`Darwin` platfrom).

This adds `Darwin` platform and installs/updates via `homebrew`.


I've also updated the template for the latest buildkite agent (v3.5.4) - which deprecates the bootstrap line item so it should be commented out.