### PR TITLE
Add option for not re/starting agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## Unreleased
 
-- Add Windows support
+### Added
 
-## 1.0.0
+- `buildkite_agent_allow_service_startup` option.
 
-- Remove support for Ubuntu 14.04; add support for Ubuntu 16.04.
-- Remove support for Buildkite Agent v2; add support for Buildkite Agent v3.
+## 1.1.0 - 2018-12-11
+
+### Added
+
+- macOS support - #7
+- Windows support - #6
+
+## 1.0.0 - 2018-04-18
+
+### Added
+
+- Support for Buildkite Agent v3.
+- Support for Ubuntu 16.04.
+
+### Removed
+
+- Remove support for Ubuntu 14.04.
+- Remove support for Buildkite Agent v2.
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Variable names below map to [the agent configuration documentation](https://buil
 
 - `buildkite_agent_nssm_version` - Which version of [NSSM] to use to manage the buildkite-agent process as a service.
 
+##### Windows gotchas
+
+- Don't use the buildkite-agent user-profile directory for anything. It will not exist until _after_ the service has been started for the first time, because ... Windows.
+
 #### Darwin
 
 - `buildkite_agent_load_bash_profile` - Load `$HOME/.bash_profile` with buildkite agent environment hook. Ensures agent will load with bash environment.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 
 ### Core
 
+- `buildkite_agent_allow_service_startup` - if false, this role will not attempt to re|start the buildkite-agent service. This is useful if you use alternative means to provision the registration token.
 - `buildkite_agent_count` - Number of agents [if you want to run multiple per host](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents).
 - `buildkite_agent_conf_dir` - Buildkite Agent configuration directory (default: `/etc/buildkite-agent`)
-- `buildkite_agent_token` - Buildkite API token
+- `buildkite_agent_token` - Buildkite agent registration token. Available from `https://buildkite.com/organizations/{org-slug}/agents`.
 - `buildkite_agent_debug` - Flag to enable Buildkite Agent debugging
 - `buildkite_agent_windows_grant_admin` - If `True` make the `buildkite-agent` user be a member of the local `Administrators` group. You must assess your own security risk tradeoff with the necessity for Windows build tools needing privileges.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,14 @@ buildkite_agent_home_dir:
   Debian: "/var/lib/buildkite-agent"
   Windows: "c:/users/buildkite-agent"
 buildkite_agent_token: ""
+
+# Allow the handlers to re|start service during this role.
+# If you retrieve the registration token secret via some other means, setting these
+# to false allows you to avoid service-startup errors until that's complete.
+buildkite_agent_allow_service_startup:
+  Darwin: true
+  Debian: true
+  Windows: true
 buildkite_agent_windows_grant_admin: False
 
 # paths config

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,18 +2,18 @@
 - name: restart-systemd-buildkite
   systemd: name=buildkite-agent@{{item}} state=restarted
   with_sequence: start=1 end={{buildkite_agent_count}} stride=1
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" && buildkite_agent_allow_service_startup[ansible_os_family]
 
 - name: restart-windows-buildkite
   win_service:
     name: buildkite-agent
     state: restarted
-  when: ansible_os_family == "Windows"
+  when: ansible_os_family == "Windows" && buildkite_agent_allow_service_startup[ansible_os_family]
 
 - name: Restart Buildkite Agent and Register for Login
   command: /usr/local/bin/brew services restart buildkite/buildkite/buildkite-agent
-  when: ansible_os_family == "Darwin"
+  when: ansible_os_family == "Darwin" && buildkite_agent_allow_service_startup[ansible_os_family]
 
 - name: Start Buildkite Agent and Register for Login
   command: /usr/local/bin/brew services start buildkite/buildkite/buildkite-agent
-  when: ansible_os_family == "Darwin"
+  when: ansible_os_family == "Darwin" && buildkite_agent_allow_service_startup[ansible_os_family]

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -60,10 +60,10 @@
     state: "{{ 'started' if buildkite_agent_allow_service_startup[ansible_os_family] else 'present' }}"
     # password lookup plugin will return the contents of the file if it exists
     password: "{{ lookup('password', '/tmp/bk-agent-password') }}"
-    application: 'c:/program files/buildkite-agent/buildkite-agent.exe'
+    application: "c:/program files/buildkite-agent/buildkite-agent.exe"
     app_parameters_free_form: start --config '{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg'
-    stdout_file: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log'
-    stderr_file: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log'
+    stdout_file: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log"
+    stderr_file: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log"
 
 - name: make necessary directories
   win_file:

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -5,7 +5,7 @@
     name: "buildkite-agent"
     # TODO: Single static file with no isolation between runs is unsafe (but that's unlikely to occur)
     # TODO: remove the password file afterwards
-    password: "{{ lookup('password', '/tmp/bk-agent-password length=32 chars=ascii_letters,digits,hexdigits,punctuation') }}"
+    password: "{{ lookup('password', '/tmp/bk-agent-password length=32 chars=ascii_letters,digits,@') }}"
     password_never_expires: yes
     user_cannot_change_password: yes
 

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -57,7 +57,7 @@
   win_nssm:
     name: buildkite-agent
     user: buildkite-agent
-    state: started
+    state: "{{ 'started' if buildkite_agent_allow_service_startup[ansible_os_family] else 'present' }}"
     # password lookup plugin will return the contents of the file if it exists
     password: "{{ lookup('password', '/tmp/bk-agent-password') }}"
     application: 'c:/program files/buildkite-agent/buildkite-agent.exe'
@@ -65,12 +65,7 @@
     stdout_file: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log'
     stderr_file: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log'
 
-- name: restart the service to force the home directory
-  win_service:
-    name: buildkite-agent
-    state: restarted
-
-- name: make necessary directories, after user home directory exists
+- name: make necessary directories
   win_file:
     state: directory
     path: '{{ item }}'


### PR DESCRIPTION
... to allow for secrets retrieval out-of-band. Over here, we use hashicorp vault to store the secrets for registration token and source control, then orchestrate those via system boot tasks. Therefore, the agent processes cannot start up until that has completed, so make the handlers optional but default-on.

Also update changelog to reflect what's happened.