### PR TITLE
Workaround buildkite-agent absolute path issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vagrant
+.venv
+.vscode
 *.retry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `buildkite_agent_allow_service_startup` option.
 - `buildkite_agent_expose_secrets` option.
+- `buildkite_agent_start_parameters` option.
 
 ## 1.1.0 - 2018-12-11
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 ### Core
 
 - `buildkite_agent_allow_service_startup` - if false, this role will not attempt to re|start the buildkite-agent service. This is useful if you use alternative means to provision the registration token.
-- `buildkite_agent_count` - Number of agents [if you want to run multiple per host](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents).
 - `buildkite_agent_conf_dir` - Buildkite Agent configuration directory (default: `/etc/buildkite-agent`)
+- `buildkite_agent_count` - Number of agents [if you want to run multiple per host](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents).
+- `buildkite_agent_debug` - Flag to enable Buildkite Agent debugging.
+- `buildkite_agent_start_parameters` - supply parameters for the `buildkite start` command.
 - `buildkite_agent_token` - Buildkite agent registration token. Available from `https://buildkite.com/organizations/{org-slug}/agents`.
-- `buildkite_agent_debug` - Flag to enable Buildkite Agent debugging
 
 ### Paths-related
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,8 +60,8 @@ buildkite_agent_tags_from_host: "false"
 
 # Debian options
 buildkite_agent_allow_latest: yes
-buildkite_agent_version: "3.4.0"
-buildkite_agent_build_number: "2484"
+buildkite_agent_version: "3.7.0"
+buildkite_agent_build_number: "2659"
 
 # Windows options
 buildkite_agent_nssm_version: "2.24.101.20180116"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 buildkite_agent_conf_dir:
   Darwin: "/usr/local/etc/buildkite-agent"
   Debian: "/etc/buildkite-agent"
-  Windows: "c:/programdata/buildkite-agent"
+  Windows: "c:/buildkite-agent"
 buildkite_agent_count: 1
 buildkite_agent_debug: "false"
 buildkite_agent_home_dir:
@@ -48,6 +48,10 @@ buildkite_agent_no_pty: "false"
 buildkite_agent_no_ssh_keyscan: "false"
 buildkite_agent_priority: 1
 buildkite_agent_queue: "default"
+buildkite_agent_start_parameters:
+  Darwin: ""
+  Debian: ""
+  Windows: "--config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
 buildkite_agent_tags: []
 buildkite_agent_tags_from_ec2: "false"
 buildkite_agent_tags_from_ec2_tags: "false"

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -65,7 +65,7 @@
     # password lookup plugin will return the contents of the file if it exists
     password: "{{ user_password }}"
     application: "c:/program files/buildkite-agent/buildkite-agent.exe"
-    app_parameters_free_form: start --config '{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg'
+    app_parameters_free_form: start {{ buildkite_agent_start_parameters[ansible_os_family] }}
     stdout_file: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log"
     stderr_file: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log"
 

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -58,7 +58,7 @@
 - name: install nssm to manage the process as a service
   win_chocolatey:
     name: nssm
-    version: "{{ buildkite_agent_nssm_version }}"
+    version: "{{ buildkite_agent_nssm_version | default('2.24.101.20180116') }}"
 
 # starting the service triggers the home directory to be created.
 # if the home directory exists already, windows will dodge that and not use it.

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -43,6 +43,11 @@
     creates: 'c:/program files/buildkite-agent/buildkite-agent.exe'
     delete_archive: yes
 
+- name: delete the shipped configuration stub to avoid binary picking it up (buildkite/agent#881)
+  win_file:
+    state: absent
+    path: c:/program files/buildkite-agent/buildkite-agent.cfg
+
 - name: render the configuration template
   win_template:
     src: "buildkite-agent.cfg.j2"


### PR DESCRIPTION
Works around buildkite-agent absolute path problem - doesn't understand drive-rooted paths on windows. See also buildkite/agent#881.

Makes the start parameters configurable. Also delete the configuration file from the zip file, because the agent prefers to find its configuration next-door to the binary ahead of any of the search paths, and if the stub is in place it'll use that in preference to our rendered version.