### PR TITLE
Add option: buildkite_agent_tags_from_gcp_labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `buildkite_agent_allow_service_startup` option.
 - `buildkite_agent_expose_secrets` option.
 - `buildkite_agent_start_parameters` option.
-- `buildkite_tags_from_gcp_labels` option.
+- `buildkite_agent_tags_from_gcp_labels` option.
 
 ## 1.1.0 - 2018-12-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `buildkite_agent_allow_service_startup` option.
 - `buildkite_agent_expose_secrets` option.
 - `buildkite_agent_start_parameters` option.
+- `buildkite_tags_from_gcp_labels` option.
 
 ## 1.1.0 - 2018-12-11
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Variable names below map to [the agent configuration documentation](https://buil
 - `buildkite_agent_tags_from_ec2_tags`
 - `buildkite_agent_tags_from_ec2`
 - `buildkite_agent_tags_from_gcp`
+- `buildkite_agent_tags_from_gcp_labels`
 - `buildkite_agent_tags_from_host`
 - `buildkite_agent_tags` - List of tags for agent; Don't use this to set `queue`, as that is handled via `buildkite_agent_queue` (default: `[]`)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ buildkite_agent_tags: []
 buildkite_agent_tags_from_ec2: "false"
 buildkite_agent_tags_from_ec2_tags: "false"
 buildkite_agent_tags_from_gcp: "false"
+buildkite_agent_tags_from_gcp_labels: "false"
 buildkite_agent_tags_from_host: "false"
 
 # Debian options

--- a/templates/buildkite-agent.cfg.j2
+++ b/templates/buildkite-agent.cfg.j2
@@ -16,8 +16,11 @@ tags-from-ec2={{ buildkite_agent_tags_from_ec2 }}
 # Include the host's EC2 tags as tags
 tags-from-ec2-tags={{ buildkite_agent_tags_from_ec2_tags }}
 
-# Include the host's Google Cloud meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
+# Include the host's Google Cloud instance meta-data as tags (instance-id, machine-type, preemptible, project-id, region, and zone)
 tags-from-gcp={{ buildkite_agent_tags_from_gcp }}
+
+# Include the host's Google Cloud instance labels as tags
+tags-from-gcp-labels={{ buildkite_agent_tags_from_gcp_labels }}
 
 # Include the host's meta-data as tags (`hostname`, `machine-id`, and `os`)
 tags-from-host={{ buildkite_agent_tags_from_host }}


### PR DESCRIPTION
This adds support for the new buildkite agent configuration option introduced in https://github.com/buildkite/agent/pull/930.