### PR TITLE
Make start parameters cross platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `buildkite_agent_allow_service_startup` option.
 - `buildkite_agent_expose_secrets` option.
-- `buildkite_agent_start_parameters` option.
+- `buildkite_agent_start_parameters` option for Debian and Windows.
+- Debian `buildkite_agent_systemd_override_template` option.
+  - Related - stop using systemd _template_ unit file (because `buildkite_agent_start_parameters` and v3.6.0+ allow `--spawn` for multiple job-runners).
 
 ## 1.1.0 - 2018-12-11
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Variable names below map to [the agent configuration documentation](https://buil
   - **NOTE:** ignored, on Windows (no package manager install option).
 - `buildkite_agent_version` - the main semantic version number to install, when `buildkite_agent_allow_latest` is `False`.
 - `buildkite_agent_build_number` - the build number (ubuntu package name includes this).
+- `buildkite_agent_systemd_override_template` - the template source for the systemd unit override.
 
 #### Windows
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,6 +63,7 @@ buildkite_agent_tags_from_host: "false"
 buildkite_agent_allow_latest: yes
 buildkite_agent_version: "3.7.0"
 buildkite_agent_build_number: "2659"
+buildkite_agent_systemd_override_template: buildkite-agent.override.conf.j2
 
 # Windows options
 buildkite_agent_nssm_version: "2.24.101.20180116"

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -2,11 +2,13 @@
 # https://buildkite.com/docs/agent/v3/osx
 # TODO:
 # * Conditionally upgrade when already present - `brew update && brew upgrade buildkite-agent`
-- homebrew_tap:
+- name: Add buildkite's tap
+  homebrew_tap:
     name: buildkite/buildkite
     state: present
 
-- homebrew:
+- name: Install buildkite-agent
+  homebrew:
     name: buildkite-agent
     state: latest
     update_homebrew: yes

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -34,7 +34,7 @@
 
 - name: Create systemd unit override
   template:
-    src: buildkite-agent.override.conf.j2
+    src: "{{ buildkite_agent_systemd_override_template }}"
     dest: /etc/systemd/system/buildkite-agent.service.d/override.conf
     owner: buildkite-agent
     group: buildkite-agent

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -32,6 +32,11 @@
   notify:
     - restart-systemd-buildkite
 
+- name: Create systemd unit override directory
+  file:
+    path: /etc/systemd/system/buildkite-agent.service.d
+    state: directory
+
 - name: Create systemd unit override
   template:
     src: "{{ buildkite_agent_systemd_override_template }}"

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -36,14 +36,17 @@
   file:
     path: /etc/systemd/system/buildkite-agent.service.d
     state: directory
+    owner: root
+    group: root
+    mode: "0755"
 
 - name: Create systemd unit override
   template:
     src: "{{ buildkite_agent_systemd_override_template }}"
-    dest: /etc/systemd/system/buildkite-agent.service.d/override.conf
-    owner: buildkite-agent
-    group: buildkite-agent
-    mode: "0600"
+    dest: /etc/systemd/system/buildkite-agent.service.d/100-set-start-spawn.conf
+    owner: root
+    group: root
+    mode: "0644"
   notify:
     - restart-systemd-buildkite
 

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -32,13 +32,19 @@
   notify:
     - restart-systemd-buildkite
 
-# because: we run the template unit
-- name: Turn off the installed service
-  service:
-    name: buildkite-agent
-    enabled: no
-    state: stopped
+- name: Create systemd unit override
+  template:
+    src: buildkite-agent.override.conf.j2
+    dest: /etc/systemd/system/buildkite-agent.service.d/override.conf
+    owner: buildkite-agent
+    group: buildkite-agent
+    mode: "0600"
+  notify:
+    - restart-systemd-buildkite
 
-- name: "Create buildkite-agent service instances"
-  systemd: name=buildkite-agent@{{item}} state=started enabled=yes
-  with_sequence: start=1 end={{buildkite_agent_count}} stride=1
+- name: Create buildkite-agent service instance
+  systemd:
+    name: buildkite-agent
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/templates/buildkite-agent.override.conf.j2
+++ b/templates/buildkite-agent.override.conf.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+[Service]
+# Must unset ExecStart before redefining, otherwise there are 2, which is an error.
+# https://askubuntu.com/questions/659267/how-do-i-override-or-configure-systemd-services
+ExecStart=
+ExecStart=/usr/bin/buildkite-agent start {{ buildkite_agent_start_parameters[ansible_os_family] }}


### PR DESCRIPTION
... because this allows multiple agent runners via `v3.6.0`'s `--spawn` flag. https://github.com/buildkite/agent/releases/tag/v3.6.0