### PR TITLE
Debian starts systemd service conditionally

### DIFF
--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -56,3 +56,4 @@
     state: started
     enabled: true
     daemon_reload: true
+  when: ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -56,4 +56,4 @@
     state: started
     enabled: true
     daemon_reload: true
-  when: ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]
+  when: buildkite_agent_allow_service_startup[ansible_os_family]

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -53,7 +53,6 @@
 - name: Create buildkite-agent service instance
   systemd:
     name: buildkite-agent
-    state: started
+    state: "{{ buildkite_agent_allow_service_startup[ansible_os_family] | ternary('started', 'stopped') }}"
     enabled: true
     daemon_reload: true
-  when: buildkite_agent_allow_service_startup[ansible_os_family]


### PR DESCRIPTION
It looks like the `buildkite_agent_allow_service_startup` isn't taking effect on the Debian install, I noticed that when `false` the `systemd` service still attempted to start.