### PR TITLE
Ability to override all tags (inc queue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.2.1 - 2019-04-25
+
+- `buildkite_agent_tags_including_queue` option.
+
 ## 1.2.0 - 2019-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Variable names below map to [the agent configuration documentation](https://buil
 - `buildkite_agent_tags_from_gcp_labels`
 - `buildkite_agent_tags_from_host`
 - `buildkite_agent_tags` - List of tags for agent; Don't use this to set `queue`, as that is handled via `buildkite_agent_queue` (default: `[]`)
+- `buildkite_agent_tags_including_queue` - List of tags for the agent that include `queue`. (default: `queue={{ buildkite_agent_queue}},{{ buildkite_agent_tags }}`)
 
 ### Platform specific settings
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,7 @@ buildkite_agent_start_parameters:
   Debian: ""
   Windows: "--config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
 buildkite_agent_tags: []
+buildkite_agent_tags_including_queue: "{{ ([['queue', buildkite_agent_queue] | join('=')] + buildkite_agent_tags) | join(',') }}"
 buildkite_agent_tags_from_ec2: "false"
 buildkite_agent_tags_from_ec2_tags: "false"
 buildkite_agent_tags_from_gcp: "false"

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -53,6 +53,6 @@
 - name: Create buildkite-agent service instance
   systemd:
     name: buildkite-agent
-    state: started
+    state: "{{ buildkite_agent_allow_service_startup[ansible_os_family] | ternary('started', 'stopped') }}"
     enabled: true
     daemon_reload: true

--- a/templates/buildkite-agent.cfg.j2
+++ b/templates/buildkite-agent.cfg.j2
@@ -8,7 +8,7 @@ name="%hostname-%n"
 priority={{ buildkite_agent_priority }}
 
 # Tags for the agent (default is "queue=default")
-tags={{ ([['queue', buildkite_agent_queue] | join('=')] + buildkite_agent_tags) | join(',') }}
+tags={{ buildkite_agent_tags_including_queue }}
 
 # Include the host's EC2 meta-data as tags (instance-id, instance-type, and ami-id)
 tags-from-ec2={{ buildkite_agent_tags_from_ec2 }}


### PR DESCRIPTION
I've added an option `buildkite_agent_tags_including_queue` which allows users to override all of the agent tags inclusive of `queue`. This is useful if for example you're using the `buildkite_agent_tags_from_gcp_labels` option and your GCE labels contain a queue name.

This is necessary for the situation above otherwise you'll end up with duplicate `queue` tags.