### PR TITLE
bootstrap-script: This is not deprecated in 3.11.x

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ buildkite_agent_plugins_dir:
 # configuration values, see https://buildkite.com/docs/agent/v3/configuration
 # note: the booleans are quoted otherwise they are rendered capitalised.
 buildkite_agent_bootstrap_script:
-  Darwin: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/bootstrap.sh"
+  Darwin: "buildkite-agent bootstrap"
   Debian: "buildkite-agent bootstrap"
   Windows: "buildkite-agent bootstrap"
 buildkite_agent_git_clean_flags: "-fxdq"

--- a/templates/buildkite-agent.cfg.j2
+++ b/templates/buildkite-agent.cfg.j2
@@ -28,7 +28,7 @@ tags-from-host={{ buildkite_agent_tags_from_host }}
 # Path to a custom boostrap command to run. By default this is `buildkite-agent bootstrap`.
 # This allows you to override the entire execution of a job. Generally you should use hooks instead!
 # See https://buildkite.com/docs/agent/hooks
-# bootstrap-script="{{ buildkite_agent_bootstrap_script[ansible_os_family] }}" # Deprecated in latest buildkite version
+bootstrap-script="{{ buildkite_agent_bootstrap_script[ansible_os_family] }}"
 
 # Path to where the builds will run from
 build-path="{{ buildkite_agent_builds_dir[ansible_os_family] }}"


### PR DESCRIPTION
https://buildkite.com/docs/agent/v3/configuration#configuration-settings still talks about it.