### PR TITLE
Depend on ansible 2.8 for win_user_profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- require ansible `2.8.x` for `win_user_profile` support.
+
 ## 1.2.1 - 2019-04-25
 
 - `buildkite_agent_tags_including_queue` option.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   license: Apache
   # 2.7.5 because https://github.com/ansible/ansible/issues/48728 via
   # https://github.com/ansible/ansible/blob/stable-2.7/changelogs/CHANGELOG-v2.7.rst#bugfixes
-  min_ansible_version: 2.7.5
+  min_ansible_version: 2.8.0
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
I propose to bump the major version of the role to 2 when releasing this.