### PR TITLE
Add user & group for darwin, making non-privileged user explicit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-...
+- Added user+group creation to macOS to make explicit running as a non-privileged user.
 
 ## 3.0.0 - 2019-11-13
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Variable names below map to [the agent configuration documentation](https://buil
 - `buildkite_agent_tags` - List of tags for agent; Don't use this to set `queue`, as that is handled via `buildkite_agent_queue` (default: `[]`)
 - `buildkite_agent_tags_including_queue` - List of tags for the agent that include `queue`. (default: `queue={{ buildkite_agent_queue}},{{ buildkite_agent_tags }}`)
 - `buildkite_agent_username` - the username to run the `buildkite-agent` process/service as.
+- `buildkite_agent_extra_user_groups` - any groups besides `buildkite-agent` that the user should be a member of. For example, on macOS, `_developer`.
 - `buildkite_agent_user_description` - the description of the user to run the `buildkite-agent` process/service as.
 
 ### Platform specific settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 # core
 buildkite_agent_username: "buildkite-agent"
+buildkite_agent_extra_user_groups:
+  Darwin: []
+  Debian: []
+  Windows: []
 buildkite_agent_user_description: "Runs BuildKite jobs. See https://buildkite.com/docs/agent/v3/."
 buildkite_agent_conf_dir:  # https://github.com/buildkite/agent/blob/master/clicommand/agent_start.go#L100
   Darwin: "/usr/local/etc/buildkite-agent"

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -1,4 +1,19 @@
 ---
+- name: Add buildkite-agent group
+  group:
+    name: "{{ buildkite_agent_username }}"
+    state: present
+
+- name: Add buildkite-agent user
+  user:
+    append: yes
+    create_home: yes
+    groups: "{{ buildkite_agent_extra_user_groups[ansible_os_family] + buildkite_agent_username }}"
+    home: "/Users/{{ buildkite_agent_username }}"
+    name: "{{ buildkite_agent_username }}"
+    shell: /bin/bash
+    state: present
+
 # https://buildkite.com/docs/agent/v3/osx
 # TODO:
 # * Conditionally upgrade when already present - `brew update && brew upgrade buildkite-agent`


### PR DESCRIPTION
## Changes

* make it explicit, for macOS, that the agent runs as a particular user inside a group.
* make it possible, for macOS, to add that user into more groups.

## Verification

<!-- How you tested it? How do you know it works? -->
