### PR TITLE
Update install-on-Windows.yml

### DIFF
--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -53,9 +53,9 @@
 
 - name: unzip the release
   win_unzip:
-    src: 'c:/windows/temp/buildkite-agent-windows-{{ buildkite_agent_platform }}-{{ buildkite_agent_version }}.zip'
-    dest: 'c:/program files/buildkite-agent'
-    creates: 'c:/program files/buildkite-agent/buildkite-agent.exe'
+    src: "c:/windows/temp/buildkite-agent-windows-{{ buildkite_agent_platform }}-{{ buildkite_agent_version }}.zip"
+    dest: "c:/program files/buildkite-agent"
+    creates: "c:/program files/buildkite-agent/buildkite-agent.exe"
     delete_archive: yes
 
 - name: delete the shipped configuration stub to avoid binary picking it up (buildkite/agent#881)


### PR DESCRIPTION
```
TASK [ansible-buildkite-agent : unzip the release] *****************************
...
fatal: [10.49.0.14]: FAILED! => changed=false 
dest: c:/program files/buildkite-agent
msg: 'Error unzipping ''c:/windows/temp/buildkite-agent-windows-amd64-3.15.1.zip'' to ''c:/program files/buildkite-agent''!. Method: System.IO.Compression.ZipFile, Exception: Exception calling "Open" with "3" argument(s): "End of Central Directory record could not be found."'
googlecompute:   removed: false
googlecompute:   src: c:/windows/temp/buildkite-agent-windows-amd64-3.15.1.zip
```

Wrapping the parameters for win_zip with single quotes is causing the above issue.
