### PR TITLE
win_get_url in ansible 2.9 doesn't follow redirects by default

### DIFF
--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -64,7 +64,6 @@
     state: absent
     path: c:/program files/buildkite-agent/buildkite-agent.cfg
 
-
 - name: render the configuration template
   win_template:
     src: "buildkite-agent.cfg.j2"

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -50,6 +50,7 @@
     url: https://github.com/buildkite/agent/releases/download/v{{ buildkite_agent_version }}/buildkite-agent-windows-amd64-{{ buildkite_agent_version }}.zip
     dest: 'c:/windows/temp/buildkite-agent-windows-{{ buildkite_agent_platform }}-{{ buildkite_agent_version }}.zip'
     timeout: 30
+    follow_redirects: all
 
 - name: unzip the release
   win_unzip:
@@ -62,6 +63,7 @@
   win_file:
     state: absent
     path: c:/program files/buildkite-agent/buildkite-agent.cfg
+
 
 - name: render the configuration template
   win_template:


### PR DESCRIPTION
The win_get_url module has a new parameter for following redirects. 
Downloading from Github returns a 302 and saves the redirect response without it.

```
 TASK [ansible-buildkite-agent : fetch buildkite-agent windows release] *********
 task path: /code/packer/improbable.io/buildkite/ansible/buildkite-agent/roles-external/ansible-buildkite-agent/tasks/install-on-Windows.yml:48
 Friday 08 November 2019  11:54:41 +0000 (0:00:02.673)       0:07:42.335 *******
 changed: [10.49.1.20] => changed=true 
   checksum_dest: ff171f951ce5a79eb2372c38ae3397ea51bee36e
   checksum_src: ff171f951ce5a79eb2372c38ae3397ea51bee36e
   dest: c:/windows/temp/buildkite-agent-windows-amd64-3.15.1.zip
   elapsed: 0.363567
   msg: Found
   size: 630
   status_code: 302
   url: https://github.com/buildkite/agent/releases/download/v3.15.1/buildkite-agent-windows-amd64-3.15.1.zip

 TASK [ansible-buildkite-agent : unzip the release] *****************************
 task path: /code/packer/improbable.io/buildkite/ansible/buildkite-agent/roles-external/ansible-buildkite-agent/tasks/install-on-Windows.yml:54
 Friday 08 November 2019  11:54:44 +0000 (0:00:02.188)       0:07:44.523 *******
 fatal: [10.49.1.20]: FAILED! => changed=false 
   dest: c:/program files/buildkite-agent
   msg: 'Error unzipping ''c:/windows/temp/buildkite-agent-windows-amd64-3.15.1.zip'' to ''c:/program files/buildkite-agent''!. Method: System.IO.Compression.ZipFile, Exception: Exception calling "Open" with "3" argument(s): "End of Central Directory record could not be found."'
   removed: false
   src: c:/windows/temp/buildkite-agent-windows-amd64-3.15.1.zip
```