### PR TITLE
Update ansible dependency, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+## 3.0.0 - 2019-11-13
+
+Version bump for breaking change. This is the same as 2.2.1.
+
+## 2.2.1 - 2019-11-12
+
+- fixes to ansible 2.9.0 updates.
+
+## 2.2.0 - 2019-11-07
+
+- porting to support ansible 2.9.0.
+
 ## 2.1.0 - 2019-08-20
 
 - `buildkite_agent_username` option for configuring the name of the user to run the service as.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 3.0.0 - 2019-11-13
 
-Version bump for breaking change. This is the same as 2.2.1.
+Version bump for breaking change. This is the same as 2.2.1 with corrected meta/main.yml.
 
 ## 2.2.1 - 2019-11-12
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Hector Castro
   description: An Ansible role to install the Buildkite Agent.
   license: Apache
-  min_ansible_version: 2.8.0
+  min_ansible_version: 2.9.0
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Since the module won't work without ansible 2.9 (the `follow_redirects` usage) now I think we need a major version bump to signal that change cc @filipVisko.

## Changes

Version bump and changelog entry.

## Verification

Tested internally.