### PR TITLE
Make log directory be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
   - Note: on Windows, this defaults to `c:/b` because long filenames still cause problems in the 21st Century.
 - `buildkite_agent_hooks_dir` - Path to where agent will look for hooks.
 - `buildkite_agent_plugins_dir` - Path to where agent will look for plugins.
+- `buildkite_agent_logs_dir` - Path to write agent logs.
+  - Note that this option only applies to Windows, and Linux platforms with [systemd versions newer than late 2017](https://github.com/systemd/systemd/issues/3991).
 
 ### Configuration settings
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,10 @@ buildkite_agent_plugins_dir:
   Darwin: "{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins"
   Debian: "{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins"
   Windows: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/plugins"
+buildkite_agent_logs_dir:
+  Darwin: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
+  Debian: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
+  Windows: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
 
 # configuration values, see https://buildkite.com/docs/agent/v3/configuration
 # note: the booleans are quoted otherwise they are rendered capitalised.

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -101,8 +101,8 @@
     name: buildkite-agent
     application: "c:/program files/buildkite-agent/buildkite-agent.exe"
     arguments: start {{ buildkite_agent_start_parameters[ansible_os_family] }}
-    stdout_file: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log"
-    stderr_file: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.log"
+    stdout_file: "{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log"
+    stderr_file: "{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log"
     executable: "{{ buildkite_agent_nssm_exe }}"
 
 - name: configure service

--- a/templates/buildkite-agent.override.conf.j2
+++ b/templates/buildkite-agent.override.conf.j2
@@ -7,3 +7,8 @@ ExecStart=
 ExecStart=/usr/bin/buildkite-agent start {{ buildkite_agent_start_parameters[ansible_os_family] }}
 
 User={{ buildkite_agent_username }}
+
+# These options will only work on systemd newer than late 2017 (https://github.com/systemd/systemd/issues/3991)
+# On older systemd, they will generate a warning, but no error.
+StandardOutput=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}
+StandardError=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}


### PR DESCRIPTION
With the default set to the current version, this should have no effect unless the user overrides `buildkite_agent_logs_dir` at role application time.

Two caveats:
1. This doesn't work on mac, because the role does not currently configure `buildkite-agent` to capture logs.
1. On Linux, this will only work on distros with systemd from late 2017 or newer.  Older versions should just print a warning about an unknown configuration option and continue on their merry way.