### PR TITLE
Add new buildkite-executable flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
-## 4.0.0 - 2020-02-26
+## 3.1.0 - 2020-02-26
 
-Version bump for breaking change.
+Add support for shims/scripts wrapping the `buildkite-agent` binary, instead of directly calling the binary.
+If not using a shim/script, no changes are needed.
 
-- `buildkite_agent_executable` option.
-- `buildkite_agent_start_parameters` option must now always begin with `start`.
+To use a shim instead of directly calling the `buildkite-agent` binary, set `buildkite_agent_executable`
+to your shim, and `buildkite_agent_start_command` to your shim's args.
+
+- Added `buildkite_agent_executable` option.
+- Added `buildkite_agent_start_command` option.
 
 ## 3.0.0 - 2019-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+## 4.0.0 - 2020-02-26
+
+Version bump for breaking change.
+
+- `buildkite_agent_executable` option.
+- `buildkite_agent_start_parameters` option must now always begin with `start`.
+
 ## 3.0.0 - 2019-11-13
 
 Version bump for breaking change. This is the same as 2.2.1 with corrected meta/main.yml.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 3.1.0 - 2020-02-26
 
 Add support for shims/scripts wrapping the `buildkite-agent` binary, instead of directly calling the binary.
-If not using a shim/script, no changes are needed.
+This can be useful, for example, if you need to fetch your agent registration token from a secret store before running `buildkite-agent`.
 
-To use a shim instead of directly calling the `buildkite-agent` binary, set `buildkite_agent_executable`
+If not using a shim/script, no changes are needed.
+To use a shim instead of directly calling the `buildkite-agent` binary, point `buildkite_agent_executable`
 to your shim, and `buildkite_agent_start_command` to your shim's args.
 
 - Added `buildkite_agent_executable` option.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 - `buildkite_agent_count` - Number of agents [if you want to run multiple per host](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents).
 - `buildkite_agent_debug` - Flag to enable Buildkite Agent debugging.
 - `buildkite_agent_executable` - The location of the buildkite-agent executable.  Defaults to the default platform-specifc installation location.
-- `buildkite_agent_start_parameters` - supply parameters for the `buildkite` command to start the agent.  Must begin with `start`.
+- `buildkite_agent_start_parameters` - supply parameters for the `buildkite` command to start the agent.  If calling the binary directly, this must begin with `start`.
 - `buildkite_agent_token` - Buildkite agent registration token. Available from `https://buildkite.com/organizations/{org-slug}/agents`.
 
 ### Paths-related

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 - `buildkite_agent_conf_dir` - Buildkite Agent configuration directory (default: `/etc/buildkite-agent`)
 - `buildkite_agent_count` - Number of agents [if you want to run multiple per host](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents).
 - `buildkite_agent_debug` - Flag to enable Buildkite Agent debugging.
-- `buildkite_agent_start_parameters` - supply parameters for the `buildkite start` command.
+- `buildkite_agent_executable` - The location of the buildkite-agent executable.  Defaults to the default platform-specifc installation location.
+- `buildkite_agent_start_parameters` - supply parameters for the `buildkite` command to start the agent.  Must begin with `start`.
 - `buildkite_agent_token` - Buildkite agent registration token. Available from `https://buildkite.com/organizations/{org-slug}/agents`.
 
 ### Paths-related

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 - `buildkite_agent_conf_dir` - Buildkite Agent configuration directory (default: `/etc/buildkite-agent`)
 - `buildkite_agent_count` - Number of agents [if you want to run multiple per host](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents).
 - `buildkite_agent_debug` - Flag to enable Buildkite Agent debugging.
-- `buildkite_agent_executable` - The location of the buildkite-agent executable.  Defaults to the default platform-specifc installation location.
-- `buildkite_agent_start_parameters` - supply parameters for the `buildkite` command to start the agent.  If calling the binary directly, this must begin with `start`.
+- `buildkite_agent_executable` - The location of the buildkite-agent executable, or a shim/wrapper you wish to use.  Defaults to the default platform-specifc installation location.
+- `buildkite_agent_start_parameters` - Command line flags to pass to the `buildkite-agent start` command to start the agent.
+- `buildkite_agent_start_command` - Arguments passed verbatim to the `buildkite_agent_executable` at startup.  Wraps `buildkite_agent_start_parameters` by default - if using a shim or script for `buildkite_agent_executable`, override this instead of `buildkite_agent_start_parameters`.
 - `buildkite_agent_token` - Buildkite agent registration token. Available from `https://buildkite.com/organizations/{org-slug}/agents`.
 
 ### Paths-related

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,9 +62,13 @@ buildkite_agent_no_ssh_keyscan: "false"
 buildkite_agent_priority: 1
 buildkite_agent_queue: "default"
 buildkite_agent_start_parameters:
-  Darwin: "start "
-  Debian: "start "
-  Windows: "start --config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
+  Darwin: ""
+  Debian: ""
+  Windows: "--config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
+buildkite_agent_start_command:
+  Darwin: "start {{buildkite_agent_start_parameters[ansible_os_family]}}"
+  Debian: "start {{buildkite_agent_start_parameters[ansible_os_family]}}"
+  Windows: "start {{buildkite_agent_start_parameters[ansible_os_family]}}"
 buildkite_agent_tags: []
 buildkite_agent_tags_including_queue: "{{ ([['queue', buildkite_agent_queue] | join('=')] + buildkite_agent_tags) | join(',') }}"
 buildkite_agent_tags_from_ec2: "false"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ buildkite_agent_conf_dir:  # https://github.com/buildkite/agent/blob/master/clic
   Windows: "c:/users/{{ buildkite_agent_username }}/AppData/Local/buildkite-agent"
 buildkite_agent_count: 1
 buildkite_agent_debug: "false"
+buildkite_agent_executable:
+  Darwin: "/usr/bin/buildkite-agent"
+  Debian: "/usr/bin/buildkite-agent"
+  Windows: "c:/program files/buildkite-agent/buildkite-agent.exe"
 buildkite_agent_hide_secrets: true
 buildkite_agent_home_dir:
   Darwin: "/usr/local/var/{{ buildkite_agent_username }}"
@@ -58,9 +62,9 @@ buildkite_agent_no_ssh_keyscan: "false"
 buildkite_agent_priority: 1
 buildkite_agent_queue: "default"
 buildkite_agent_start_parameters:
-  Darwin: ""
-  Debian: ""
-  Windows: "--config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
+  Darwin: "start "
+  Debian: "start "
+  Windows: "start --config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
 buildkite_agent_tags: []
 buildkite_agent_tags_including_queue: "{{ ([['queue', buildkite_agent_queue] | join('=')] + buildkite_agent_tags) | join(',') }}"
 buildkite_agent_tags_from_ec2: "false"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,9 +66,9 @@ buildkite_agent_start_parameters:
   Debian: ""
   Windows: "--config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
 buildkite_agent_start_command:
-  Darwin: "start {{buildkite_agent_start_parameters[ansible_os_family]}}"
-  Debian: "start {{buildkite_agent_start_parameters[ansible_os_family]}}"
-  Windows: "start {{buildkite_agent_start_parameters[ansible_os_family]}}"
+  Darwin: "start {{ buildkite_agent_start_parameters[ansible_os_family] }}"
+  Debian: "start {{ buildkite_agent_start_parameters[ansible_os_family] }}"
+  Windows: "start { {buildkite_agent_start_parameters[ansible_os_family] }}"
 buildkite_agent_tags: []
 buildkite_agent_tags_including_queue: "{{ ([['queue', buildkite_agent_queue] | join('=')] + buildkite_agent_tags) | join(',') }}"
 buildkite_agent_tags_from_ec2: "false"

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -100,7 +100,7 @@
   win_nssm:
     name: buildkite-agent
     application: "{{ buildkite_agent_executable[ansible_os_family] }}"
-    arguments: "{{ buildkite_agent_start_parameters[ansible_os_family] }}"
+    arguments: "{{ buildkite_agent_start_command[ansible_os_family] }}"
     stdout_file: "{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log"
     stderr_file: "{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log"
     executable: "{{ buildkite_agent_nssm_exe }}"

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -99,8 +99,8 @@
 - name: configure buildkite-agent as an nssm service
   win_nssm:
     name: buildkite-agent
-    application: "c:/program files/buildkite-agent/buildkite-agent.exe"
-    arguments: start {{ buildkite_agent_start_parameters[ansible_os_family] }}
+    application: "{{ buildkite_agent_executable[ansible_os_family] }}"
+    arguments: "{{ buildkite_agent_start_parameters[ansible_os_family] }}"
     stdout_file: "{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log"
     stderr_file: "{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log"
     executable: "{{ buildkite_agent_nssm_exe }}"

--- a/templates/buildkite-agent.override.conf.j2
+++ b/templates/buildkite-agent.override.conf.j2
@@ -4,7 +4,7 @@
 # Must unset ExecStart before redefining, otherwise there are 2, which is an error.
 # https://askubuntu.com/questions/659267/how-do-i-override-or-configure-systemd-services
 ExecStart=
-ExecStart=/usr/bin/buildkite-agent start {{ buildkite_agent_start_parameters[ansible_os_family] }}
+ExecStart={{ buildkite_agent_executable[ansible_os_family] }} start {{ buildkite_agent_start_parameters[ansible_os_family] }}
 
 User={{ buildkite_agent_username }}
 

--- a/templates/buildkite-agent.override.conf.j2
+++ b/templates/buildkite-agent.override.conf.j2
@@ -4,7 +4,7 @@
 # Must unset ExecStart before redefining, otherwise there are 2, which is an error.
 # https://askubuntu.com/questions/659267/how-do-i-override-or-configure-systemd-services
 ExecStart=
-ExecStart={{ buildkite_agent_executable[ansible_os_family] }} start {{ buildkite_agent_start_parameters[ansible_os_family] }}
+ExecStart={{ buildkite_agent_executable[ansible_os_family] }} {{ buildkite_agent_start_command[ansible_os_family] }}
 
 User={{ buildkite_agent_username }}
 


### PR DESCRIPTION
This allows for us to have the role run a shim or script instead of directly calling the bk-agent binary.  This also necessitates changing the behavior of `buildkite_agent_start_parameters` to allow for passing params to arbitrary commands.

Updated the readme and changelog, and bumped the version by a major, since this is a breaking change for any users who are currently passing non-default `buildkite_agent_start_parameters`.