### PR TITLE
Testing potential fix for broken 2.3.0 release of homebrew

### DIFF
--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -8,7 +8,7 @@
     state: present
 
 # Workaround for currently broken homebrew release of 2.3.0
-- name: Install buildkite-agent
+- name: Checkout the latest working commit of homebrew
   command: git checkout 2.2.17 
   args:
     chdir: /usr/local/Homebrew

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -9,9 +9,14 @@
 
 # Workaround for currently broken homebrew release of 2.3.0
 - name: Install buildkite-agent
-  command: git checkout tags/2.2.17 && HOMEBREW_NO_AUTO_UPDATE=1 brew install buildkite-agent
+  command: git checkout 2.2.17 
   args:
     chdir: /usr/local/Homebrew
+
+- name: Install buildkite-agent
+  homebrew:
+    name: buildkite-agent
+    update_homebrew: no
 
 - name: Configure Buildkite
   template:

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -17,6 +17,8 @@
   homebrew:
     name: buildkite-agent
     update_homebrew: no
+  environment:
+    HOMEBREW_NO_AUTO_UPDATE: 1
 
 - name: Configure Buildkite
   template:
@@ -34,3 +36,7 @@
   when: buildkite_agent_load_bash_profile == True
   notify:
     - "Restart Buildkite Agent and Register for Login"
+
+- name: Refresh homebrew to original state
+  command: brew update
+

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -37,6 +37,11 @@
   notify:
     - "Restart Buildkite Agent and Register for Login"
 
+- name: Reverting homebrew state back to HEAD
+  command: git checkout master
+  args:
+    chdir: /usr/local/Homebrew
+
 - name: Refresh homebrew to original state
   command: /usr/local/bin/brew update
 

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -38,5 +38,5 @@
     - "Restart Buildkite Agent and Register for Login"
 
 - name: Refresh homebrew to original state
-  command: brew update
+  command: /usr/local/bin/brew update
 

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -9,7 +9,7 @@
 
 # Workaround for currently broken homebrew release of 2.3.0
 - name: Install buildkite-agent
-  command: git checkout 2.2.17 && HOMEBREW_NO_AUTO_UPDATE=1 brew install buildkite-agent
+  command: git checkout "2.2.17" && HOMEBREW_NO_AUTO_UPDATE=1 brew install buildkite-agent
   args:
     chdir: /usr/local/Homebrew
 

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -16,7 +16,6 @@
 - name: Install buildkite-agent
   homebrew:
     name: buildkite-agent
-    update_homebrew: no
   environment:
     HOMEBREW_NO_AUTO_UPDATE: 1
 
@@ -38,7 +37,7 @@
     - "Restart Buildkite Agent and Register for Login"
 
 - name: Reverting homebrew state back to HEAD
-  command: git checkout master
+  command: git checkout stable
   args:
     chdir: /usr/local/Homebrew
 

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -9,7 +9,7 @@
 
 # Workaround for currently broken homebrew release of 2.3.0
 - name: Install buildkite-agent
-  command: git checkout "2.2.17" && HOMEBREW_NO_AUTO_UPDATE=1 brew install buildkite-agent
+  command: git checkout tags/2.2.17 && HOMEBREW_NO_AUTO_UPDATE=1 brew install buildkite-agent
   args:
     chdir: /usr/local/Homebrew
 

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -7,11 +7,11 @@
     name: buildkite/buildkite
     state: present
 
+# Workaround for currently broken homebrew release of 2.3.0
 - name: Install buildkite-agent
-  homebrew:
-    name: buildkite-agent
-    state: latest
-    update_homebrew: yes
+  command: git checkout 2.2.17 && HOMEBREW_NO_AUTO_UPDATE=1 brew install buildkite-agent
+  args:
+    chdir: /usr/local/Homebrew
 
 - name: Configure Buildkite
   template:


### PR DESCRIPTION
Temporarily locking buildkite-agent client on macOS until Homebrew is fixed.