### PR TITLE
Make the agent log output actually target a file

### DIFF
--- a/templates/buildkite-agent.override.conf.j2
+++ b/templates/buildkite-agent.override.conf.j2
@@ -10,5 +10,5 @@ User={{ buildkite_agent_username }}
 
 # These options will only work on systemd newer than late 2017 (https://github.com/systemd/systemd/issues/3991)
 # On older systemd, they will generate a warning, but no error.
-StandardOutput=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}
-StandardError=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}
+StandardOutput=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log
+StandardError=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log


### PR DESCRIPTION
The current target is an error, and you'll see this message on agent startup, which results in logs going to actual stdout, and not a file as intended:

```
[/etc/systemd/system/buildkite-agent.service.d/100-buildkite-agent-overrides-from-role.conf:14] Failed to parse output specifier, ignoring: file:/var/log/improbable
```

where in our case, `/var/log/improbable` is what we have `buildkite_agent_logs_dir[ansible_os_family]` set to in ansible.