### PR TITLE
Allow user's UID to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-...
+* Added: ability to create user (on Debian) with a specific UID.
+
+## 3.1.1: 2020-07-31
+
+* Fixed: systemd path to buildkite agent logs; needs to be a file, not a directory.
 
 ## 3.1.0 - 2020-02-26
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Variable names below map to [the agent configuration documentation](https://buil
 - `buildkite_agent_tags` - List of tags for agent; Don't use this to set `queue`, as that is handled via `buildkite_agent_queue` (default: `[]`)
 - `buildkite_agent_tags_including_queue` - List of tags for the agent that include `queue`. (default: `queue={{ buildkite_agent_queue}},{{ buildkite_agent_tags }}`)
 - `buildkite_agent_username` - the username to run the `buildkite-agent` process/service as.
+- `buildkite_agent_user_uid` - the user ID to make the user be, if specified.
+  - this is ignored on Windows.
+  - This is useful because it allows the UID to be well-known, which in turn allows people to build dockers which contain a work-user with this same UID, allowing them to avoid the otherwise-usual-problems where files are written into a host-mounted volume and the UIDs mismatch, bricking the host's filesystem for future builds.
 - `buildkite_agent_user_description` - the description of the user to run the `buildkite-agent` process/service as.
 
 ### Platform specific settings

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: restart-systemd-buildkite
   systemd:
-    name: "{{ buildkite_agent_username }}"
+    name: "buildkite-agent"
     state: restarted
   when: ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]
 
 - name: restart-windows-buildkite
   win_service:
-    name: "{{ buildkite_agent_username }}"
+    name: "buildkite-agent"
     state: restarted
   when: ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]
 

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -8,7 +8,7 @@
   user:
     name: "{{ buildkite_agent_username }}"
     home: "/var/lib/{{ buildkite_agent_username }}"  # because the deb creates /var/lib/buildkite-agent by default.
-    uid: "{{ buildkite_agent_user_uid }}"
+    uid: "{{ buildkite_agent_user_uid | default(omit) }}"
     description: "{{ buildkite_agent_user_description }}"
 
 - name: Configure the Buildkite APT key

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -7,10 +7,10 @@
 - name: Create the user to run the agent
   user:
     name: "{{ buildkite_agent_username }}"
+    create_home: yes
     home: "/var/lib/{{ buildkite_agent_username }}"  # because the deb creates /var/lib/buildkite-agent by default.
     system: yes
     uid: "{{ buildkite_agent_user_uid | default(omit) }}"
-    description: "{{ buildkite_agent_user_description }}"
 
 - name: Configure the Buildkite APT key
   apt_key:

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -1,4 +1,16 @@
 ---
+- name: Create the user's group
+  group:
+    name: "{{ buildkite_agent_username }}"
+    state: present
+
+- name: Create the user to run the agent
+  user:
+    name: "{{ buildkite_agent_username }}"
+    home: "/var/lib/{{ buildkite_agent_username }}"  # because the deb creates /var/lib/buildkite-agent by default.
+    uid: "{{ buildkite_agent_user_uid }}"
+    description: "{{ buildkite_agent_user_description }}"
+
 - name: Configure the Buildkite APT key
   apt_key:
     keyserver: hkp://keyserver.ubuntu.com:80
@@ -21,14 +33,6 @@
     pkg: "buildkite-agent={{ buildkite_agent_version }}-{{ buildkite_agent_build_number }}"
     state: present
   when: buildkite_agent_allow_latest == False
-
-# buildkite-agent user is created by deb package; if the username is customised, create that custom user.
-- name: Create the user to run the agent as if necessary
-  when: buildkite_agent_username != "buildkite-agent"
-  user:
-    name: "{{ buildkite_agent_username }}"
-    home: "/var/lib/{{ buildkite_agent_username }}"  # because the deb creates /var/lib/buildkite-agent by default.
-    description: "{{ buildkite_agent_user_description }}"
 
 - name: Configure Buildkite
   template:

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -9,6 +9,7 @@
     name: "{{ buildkite_agent_username }}"
     create_home: yes
     home: "/var/lib/{{ buildkite_agent_username }}"  # because the deb creates /var/lib/buildkite-agent by default.
+    shell: ""
     system: yes
     uid: "{{ buildkite_agent_user_uid | default(omit) }}"
 

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -8,6 +8,7 @@
   user:
     name: "{{ buildkite_agent_username }}"
     home: "/var/lib/{{ buildkite_agent_username }}"  # because the deb creates /var/lib/buildkite-agent by default.
+    system: yes
     uid: "{{ buildkite_agent_user_uid | default(omit) }}"
     description: "{{ buildkite_agent_user_description }}"
 


### PR DESCRIPTION
This is useful because it allows the UID to be well-known, which in turn allows people to build dockers which contain a work-user with this same UID, allowing them to avoid the otherwise-usual-problems where files are written into a host-mounted volume and the UIDs mismatch, bricking the host's filesystem for future builds.

https://github.com/buildkite/agent/blob/master/packaging/linux/scripts/after-install-and-upgrade.sh#L17-L19 suggests that if the user exists already, it won't be recreated.

It's useful regardless of the UID, since by creating the user ahead of installing the package, we're in total control of the user's characteristics. The deb package only creates the user if one doesn't already exist: https://github.com/buildkite/agent/blob/9254ab11e0eb9d9edfd8d78488a3ab06476ca74b/packaging/linux/scripts/after-install-and-upgrade.sh#L17-L19