### PR TITLE
ENG-3913: Make bk binary installation optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* ...
+* Fix: don't update homebrew on macOS as part of installing, since this is potentially very slow.
+* Add: make installing the binary be optional (`buildkite_agent_should_install_binary`), in case people (yes, improbable) elect to install it differently.
 
 ## 3.2.1: 2020-10-05
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 - `buildkite_agent_count` - Number of agents [if you want to run multiple per host](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents).
 - `buildkite_agent_debug` - Flag to enable Buildkite Agent debugging.
 - `buildkite_agent_executable` - The location of the buildkite-agent executable, or a shim/wrapper you wish to use.  Defaults to the default platform-specifc installation location.
+- `buildkite_agent_should_install_binary` - When `yes`, use the platform-specific installation method to install the binary. When `no`, don't. Useful if you prefer to install the binary via other means.
 - `buildkite_agent_start_parameters` - Command line flags to pass to the `buildkite-agent start` command to start the agent.
 - `buildkite_agent_start_command` - Arguments passed verbatim to the `buildkite_agent_executable` at startup.  Wraps `buildkite_agent_start_parameters` by default - if using a shim or script for `buildkite_agent_executable`, override this instead of `buildkite_agent_start_parameters`.
 - `buildkite_agent_token` - Buildkite agent registration token. Available from `https://buildkite.com/organizations/{org-slug}/agents`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ buildkite_agent_home_dir:
   Darwin: "/usr/local/var/{{ buildkite_agent_username }}"
   Debian: "/var/lib/{{ buildkite_agent_username }}"
   Windows: "c:/users/{{ buildkite_agent_username }}"
+buildkite_agent_should_install_binary: yes
 buildkite_agent_token: ""
 # Allow the handlers to re|start service during this role.
 # If you retrieve the registration token secret via some other means, setting these

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -2,16 +2,18 @@
 # https://buildkite.com/docs/agent/v3/osx
 # TODO:
 # * Conditionally upgrade when already present - `brew update && brew upgrade buildkite-agent`
-- name: Add buildkite's tap
-  homebrew_tap:
-    name: buildkite/buildkite
-    state: present
+- name: install buildkite binary
+  when: buildkite_agent_should_install_binary
+  block:
+    - name: Add buildkite's tap
+      homebrew_tap:
+        name: buildkite/buildkite
+        state: present
 
-- name: Install buildkite-agent
-  homebrew:
-    name: buildkite-agent
-    state: latest
-    update_homebrew: yes
+    - name: Install buildkite-agent
+      homebrew:
+        name: buildkite-agent
+        state: latest
 
 - name: Configure Buildkite
   template:

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -14,28 +14,31 @@
     system: yes
     uid: "{{ buildkite_agent_user_uid | default(omit) }}"
 
-- name: Configure the Buildkite APT key
-  apt_key:
-    keyserver: hkp://keyserver.ubuntu.com:80
-    id: 32A37959C2FA5C3C99EFBC32A79206696452D198
-    state: present
+- name: install buildkite binary
+  when: buildkite_agent_should_install_binary
+  block:
+    - name: Configure the Buildkite APT key
+      apt_key:
+        keyserver: hkp://keyserver.ubuntu.com:80
+        id: 32A37959C2FA5C3C99EFBC32A79206696452D198
+        state: present
 
-- name: Configure the Buildkite APT repository
-  apt_repository:
-    repo: "deb https://apt.buildkite.com/buildkite-agent stable main"
-    state: present
+    - name: Configure the Buildkite APT repository
+      apt_repository:
+        repo: "deb https://apt.buildkite.com/buildkite-agent stable main"
+        state: present
 
-- name: Install Latest Buildkite Agent
-  apt:
-    pkg: "buildkite-agent"
-    state: present
-  when: buildkite_agent_allow_latest == True
+    - name: Install Latest Buildkite Agent
+      apt:
+        pkg: "buildkite-agent"
+        state: present
+      when: buildkite_agent_allow_latest == True
 
-- name: Install Buildkite Agent
-  apt:
-    pkg: "buildkite-agent={{ buildkite_agent_version }}-{{ buildkite_agent_build_number }}"
-    state: present
-  when: buildkite_agent_allow_latest == False
+    - name: Install Buildkite Agent
+      apt:
+        pkg: "buildkite-agent={{ buildkite_agent_version }}-{{ buildkite_agent_build_number }}"
+        state: present
+      when: buildkite_agent_allow_latest == False
 
 - name: Configure Buildkite
   template:

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -45,24 +45,27 @@
     - 'c:/program files/buildkite-agent'
     - '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
 
-- name: fetch buildkite-agent windows release
-  win_get_url:
-    url: https://github.com/buildkite/agent/releases/download/v{{ buildkite_agent_version }}/buildkite-agent-windows-amd64-{{ buildkite_agent_version }}.zip
-    dest: 'c:/windows/temp/buildkite-agent-windows-{{ buildkite_agent_platform }}-{{ buildkite_agent_version }}.zip'
-    timeout: 30
-    follow_redirects: all
+- name: install buildkite binary
+  when: buildkite_agent_should_install_binary
+  block:
+    - name: fetch buildkite-agent windows release
+      win_get_url:
+        url: https://github.com/buildkite/agent/releases/download/v{{ buildkite_agent_version }}/buildkite-agent-windows-amd64-{{ buildkite_agent_version }}.zip
+        dest: 'c:/windows/temp/buildkite-agent-windows-{{ buildkite_agent_platform }}-{{ buildkite_agent_version }}.zip'
+        timeout: 30
+        follow_redirects: all
 
-- name: unzip the release
-  win_unzip:
-    src: "c:/windows/temp/buildkite-agent-windows-{{ buildkite_agent_platform }}-{{ buildkite_agent_version }}.zip"
-    dest: "c:/program files/buildkite-agent"
-    creates: "c:/program files/buildkite-agent/buildkite-agent.exe"
-    delete_archive: yes
+    - name: unzip the release
+      win_unzip:
+        src: "c:/windows/temp/buildkite-agent-windows-{{ buildkite_agent_platform }}-{{ buildkite_agent_version }}.zip"
+        dest: "c:/program files/buildkite-agent"
+        creates: "c:/program files/buildkite-agent/buildkite-agent.exe"
+        delete_archive: yes
 
-- name: delete the shipped configuration stub to avoid binary picking it up (buildkite/agent#881)
-  win_file:
-    state: absent
-    path: c:/program files/buildkite-agent/buildkite-agent.cfg
+    - name: delete the shipped configuration stub to avoid binary picking it up (buildkite/agent#881)
+      win_file:
+        state: absent
+        path: c:/program files/buildkite-agent/buildkite-agent.cfg
 
 - name: render the configuration template
   win_template:


### PR DESCRIPTION
Since we can provide it via toolshare faster and more consistently, enable that.

Also, avoid homebrew update (since it's sometimes tens of seconds).

## Changes

See changelog

## Verification

* [x] internal test run of default behaviour

Works as intended; still installs, no longer bloats up to 100ish seconds.

```
    default: ansible-buildkite-agent : Install buildkite-agent ---------------------- 19.33s
```