### PR TITLE
Fix permissions and homebrew/become

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Fix: don't accidentally run homebrew with become, it refuses.
+* Fix: correct permissions and ownership on macOS configuration file and environment hook.
+
 ## 3.3.0: 2020-10-29
 
 * Fix: don't update homebrew on macOS as part of installing, since this is potentially very slow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fix: don't accidentally run homebrew with become, it refuses.
 * Fix: correct permissions and ownership on macOS configuration file and environment hook.
+* Add: `buildkite_agent_homebrew_tap_url` (to allow overriding with an ssh-based tap for reliability).
 
 ## 3.3.0: 2020-10-29
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Variable names below map to [the agent configuration documentation](https://buil
 
 #### Darwin
 
+- `buildkite_agent_homebrew_tap_url` - You could use `git@github.com:buildkite/homebrew-buildkite.git` if you clone over ssh because you find that more reliable, but your ansible connection needs an ssh key to authenticate to github then (forwarding your ssh-agent works fine). Omitted otherwise.
 - `buildkite_agent_load_bash_profile` - Load `$HOME/.bash_profile` with buildkite agent environment hook. Ensures agent will load with bash environment.
 
 ### Debugging

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -1,7 +1,5 @@
 ---
 # https://buildkite.com/docs/agent/v3/osx
-# TODO:
-# * Conditionally upgrade when already present - `brew update && brew upgrade buildkite-agent`
 - name: install buildkite binary
   when: buildkite_agent_should_install_binary
   block:
@@ -9,17 +7,21 @@
       homebrew_tap:
         name: buildkite/buildkite
         state: present
+      become: no
 
     - name: Install buildkite-agent
       homebrew:
         name: buildkite-agent
         state: latest  # noqa 403 homebrew doesn't allow version pinning
+      become: no
 
 - name: Configure Buildkite
   template:
     src: "buildkite-agent.cfg.j2"
     dest: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
-    mode: "0600"
+    mode: "0400"
+    owner: "{{ buildkite_agent_username }}"
+    group: "wheel"
   notify:
     - "restart-darwin-buildkite"
 
@@ -27,7 +29,9 @@
   template:
     src: "buildkite-agent-hook-environment.sh"
     dest: "{{ buildkite_agent_hooks_dir[ansible_os_family] }}/environment"
-    mode: "0600"
+    mode: "0444"
+    owner: "{{ buildkite_agent_username }}"
+    group: "wheel"
   when: buildkite_agent_load_bash_profile
   notify:
     - "restart-darwin-buildkite"

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -5,7 +5,8 @@
   block:
     - name: Add buildkite's tap
       homebrew_tap:
-        name: buildkite/buildkite
+        name: "buildkite/buildkite"
+        url: "{{ buildkite_agent_homebrew_tap_url | default(omit) }}"
         state: present
       become: no
 

--- a/templates/buildkite-agent-hook-environment.sh
+++ b/templates/buildkite-agent-hook-environment.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -o errexit -o nounset -o pipefail
 [[ -f "${HOME}/.bash_profile" ]] && source "${HOME}/.bash_profile"


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

See changelog.md

## Verification

CI is failing for 
* a failure to yamlfmt. I intend to do that all in one pass, after the immediate need of this change.
* a warning from shellcheck about not following a non-constant `source` - that will be fixed in a followup with an ignore directive, since that file can never exist within the role, only at runtime on the host.
