### PR TITLE
Fix user-password handling on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 3.3.2
+## 4.0.0
 
-* Fix: Windows user password handling + doc.
+* Fix: Windows user password handling + doc. This was regressed within `3.3.1` during e1d9460, we're really sorry about that.
 
 ## 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.3.2
+
+* Fix: Windows user password handling + doc.
+
 ## 3.3.1
 
 * Fix: don't accidentally run homebrew with become, it refuses.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Variable names below map to [the agent configuration documentation](https://buil
 
 - `buildkite_agent_nssm_exe` - the full path to nssm.exe in case it's not on `PATH`.
 - `buildkite_agent_nssm_version` - Which version of [NSSM] to use to manage the buildkite-agent process as a service.
+- `buildkite_agent_user_password` - If supplied, will be used for the Windows user account, otherwise a random password will be generated.
 - `buildkite_agent_windows_grant_admin` - If `True` make the `buildkite_agent_username` user be a member of the local `Administrators` group. You must assess your own security risk tradeoff with the necessity for Windows build tools needing privileges.
 
 #### Darwin

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Variable names below map to [the agent configuration documentation](https://buil
 
 - `buildkite_agent_nssm_exe` - the full path to nssm.exe in case it's not on `PATH`.
 - `buildkite_agent_nssm_version` - Which version of [NSSM] to use to manage the buildkite-agent process as a service.
-- `buildkite_agent_user_password` - If supplied, will be used for the Windows user account, otherwise a random password will be generated.
 - `buildkite_agent_windows_grant_admin` - If `True` make the `buildkite_agent_username` user be a member of the local `Administrators` group. You must assess your own security risk tradeoff with the necessity for Windows build tools needing privileges.
 
 #### Darwin

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 - `buildkite_agent_count` - Number of agents [if you want to run multiple per host](https://buildkite.com/docs/agent/v3/ubuntu#running-multiple-agents).
 - `buildkite_agent_debug` - Flag to enable Buildkite Agent debugging.
 - `buildkite_agent_executable` - The location of the buildkite-agent executable, or a shim/wrapper you wish to use.  Defaults to the default platform-specifc installation location.
-- `buildkite_agent_should_install_binary` - When `yes`, use the platform-specific installation method to install the binary. When `no`, don't. Useful if you prefer to install the binary via other means.
+- `buildkite_agent_should_install_binary[ansible_os_family]` - When `yes`, use the platform-specific installation method to install the binary. When `no`, don't. Useful if you prefer to install the binary via other means.
 - `buildkite_agent_start_parameters` - Command line flags to pass to the `buildkite-agent start` command to start the agent.
 - `buildkite_agent_start_command` - Arguments passed verbatim to the `buildkite_agent_executable` at startup.  Wraps `buildkite_agent_start_parameters` by default - if using a shim or script for `buildkite_agent_executable`, override this instead of `buildkite_agent_start_parameters`.
 - `buildkite_agent_token` - Buildkite agent registration token. Available from `https://buildkite.com/organizations/{org-slug}/agents`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,10 @@ buildkite_agent_home_dir:
   Darwin: "/usr/local/var/{{ buildkite_agent_username }}"
   Debian: "/var/lib/{{ buildkite_agent_username }}"
   Windows: "c:/users/{{ buildkite_agent_username }}"
-buildkite_agent_should_install_binary: yes
+buildkite_agent_should_install_binary:
+  Darwin: yes
+  Debian: yes
+  Windows: yes
 buildkite_agent_token: ""
 # Allow the handlers to re|start service during this role.
 # If you retrieve the registration token secret via some other means, setting these

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 # core
 buildkite_agent_username: "buildkite-agent"
-buildkite_agent_user_password: ""  # When blank, a random password will be generated and assigned to the user.
 buildkite_agent_user_description: "Runs BuildKite jobs. See https://buildkite.com/docs/agent/v3/."
 buildkite_agent_conf_dir:  # https://github.com/buildkite/agent/blob/master/clicommand/agent_start.go#L100
   Darwin: "/usr/local/etc/buildkite-agent"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # core
 buildkite_agent_username: "buildkite-agent"
-buildkite_agent_user_password: "{{ lookup('password', '/tmp/bk-agent-password length=32 chars=ascii_letters,digits,punctuation') }}"
+buildkite_agent_user_password: ""  # When blank, a random password will be generated and assigned to the user.
 buildkite_agent_user_description: "Runs BuildKite jobs. See https://buildkite.com/docs/agent/v3/."
 buildkite_agent_conf_dir:  # https://github.com/buildkite/agent/blob/master/clicommand/agent_start.go#L100
   Darwin: "/usr/local/etc/buildkite-agent"

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -1,7 +1,7 @@
 ---
 # https://buildkite.com/docs/agent/v3/osx
 - name: install buildkite binary
-  when: buildkite_agent_should_install_binary
+  when: buildkite_agent_should_install_binary[ansible_os_family]
   block:
     - name: Add buildkite's tap
       homebrew_tap:

--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -15,7 +15,7 @@
     uid: "{{ buildkite_agent_user_uid | default(omit) }}"
 
 - name: install buildkite binary
-  when: buildkite_agent_should_install_binary
+  when: buildkite_agent_should_install_binary[ansible_os_family]
   block:
     - name: Configure the Buildkite APT key
       apt_key:

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -1,6 +1,6 @@
 ---
 - name: generate password if needed
-  when: buildkite_agent_user_password == ''
+  when: buildkite_agent_user_password | length == 0
   set_fact:
     buildkite_agent_user_generated_password: "{{ lookup('password', '/tmp/bk-agent-password length=32 chars=ascii_letters,digits,punctuation') }}"
 
@@ -8,7 +8,7 @@
   win_user:
     description: "{{ buildkite_agent_user_description }}"
     name: "{{ buildkite_agent_username }}"
-    password: "{{ (buildkite_agent_user_password == '') | ternary(buildkite_agent_user_generated_password, buildkite_agent_user_password) }}"
+    password: "{{ (buildkite_agent_user_password | length == 0) | ternary(buildkite_agent_user_generated_password, buildkite_agent_user_password) }}"
     password_never_expires: yes
     user_cannot_change_password: yes
   register: buildkite_agent_user
@@ -111,5 +111,5 @@
   win_service:
     name: buildkite-agent
     username: "{{ buildkite_agent_username }}"
-    password: "{{ (buildkite_agent_user_password == '') | ternary(buildkite_agent_user_generated_password, buildkite_agent_user_password) }}"
+    password: "{{ (buildkite_agent_user_password | length == 0) | ternary(buildkite_agent_user_generated_password, buildkite_agent_user_password) }}"
     state: "{{ buildkite_agent_allow_service_startup[ansible_os_family] | ternary('started', 'stopped') }}"

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -2,7 +2,7 @@
 - name: generate password if needed
   when: buildkite_agent_user_password == ''
   set_fact:
-    buildkite_agent_user_generated_password: "{{ lookup('password', '/tmp/bk-agent-password-'+ inventory_hostname | replace('.', '-') +' length=32 chars=ascii_letters,digits,punctuation') }}"
+    buildkite_agent_user_generated_password: "{{ lookup('password', '/tmp/bk-agent-password length=32 chars=ascii_letters,digits,punctuation') }}"
 
 - name: make the user
   win_user:

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -1,14 +1,14 @@
 ---
-- name: generate password if needed
-  when: buildkite_agent_user_password | length == 0
+- name: make password for user
   set_fact:
-    buildkite_agent_user_generated_password: "{{ lookup('password', '/tmp/bk-agent-password length=32 chars=ascii_letters,digits,punctuation') }}"
+    buildkite_agent_user_password: "{{ lookup('password', '/tmp/bk-agent-password length=32 chars=ascii_letters,digits,punctuation') }}"
+  no_log: "{{ buildkite_agent_hide_secrets | default(true) }}"
 
 - name: make the user
   win_user:
     description: "{{ buildkite_agent_user_description }}"
     name: "{{ buildkite_agent_username }}"
-    password: "{{ (buildkite_agent_user_password | length == 0) | ternary(buildkite_agent_user_generated_password, buildkite_agent_user_password) }}"
+    password: "{{ buildkite_agent_user_password }}"
     password_never_expires: yes
     user_cannot_change_password: yes
   register: buildkite_agent_user
@@ -111,5 +111,5 @@
   win_service:
     name: buildkite-agent
     username: "{{ buildkite_agent_username }}"
-    password: "{{ (buildkite_agent_user_password | length == 0) | ternary(buildkite_agent_user_generated_password, buildkite_agent_user_password) }}"
+    password: "{{ buildkite_agent_user_password }}"
     state: "{{ buildkite_agent_allow_service_startup[ansible_os_family] | ternary('started', 'stopped') }}"

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -45,7 +45,7 @@
     - '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
 
 - name: install buildkite binary
-  when: buildkite_agent_should_install_binary
+  when: buildkite_agent_should_install_binary[ansible_os_family]
   block:
     - name: fetch buildkite-agent windows release
       win_get_url:

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -1,10 +1,14 @@
 ---
+- name: generate password if needed
+  when: buildkite_agent_user_password == ''
+  set_fact:
+    buildkite_agent_user_generated_password: "{{ lookup('password', '/tmp/bk-agent-password-'+ inventory_hostname | replace('.', '-') +' length=32 chars=ascii_letters,digits,punctuation') }}"
+
 - name: make the user
   win_user:
     description: "{{ buildkite_agent_user_description }}"
     name: "{{ buildkite_agent_username }}"
-    # TODO: Single static file with no isolation between runs is unsafe (but that's unlikely to occur)
-    password: "{{ buildkite_agent_user_password }}"
+    password: "{{ (buildkite_agent_user_password == '') | ternary(buildkite_agent_user_generated_password, buildkite_agent_user_password) }}"
     password_never_expires: yes
     user_cannot_change_password: yes
   register: buildkite_agent_user
@@ -107,5 +111,5 @@
   win_service:
     name: buildkite-agent
     username: "{{ buildkite_agent_username }}"
-    password: "{{ buildkite_agent_user_password }}"
-    state: "{{ 'started' if buildkite_agent_allow_service_startup[ansible_os_family] else 'stopped' }}"
+    password: "{{ (buildkite_agent_user_password == '') | ternary(buildkite_agent_user_generated_password, buildkite_agent_user_password) }}"
+    state: "{{ buildkite_agent_allow_service_startup[ansible_os_family] | ternary('started', 'stopped') }}"


### PR DESCRIPTION
## Changes

Revert a change (ability to supply password, introduced in e1d9460 while fixing lint :-( ) that caused an internal regression; bump major version in case anyone was relying on that new-and-now-removed behaviour.

Allow the binary installation choice to be feature-flagged per platform.

Non-functional change to ternary logic in one `when`.

## Verification

<!-- How you tested it? How do you know it works? -->
