### PR TITLE
Add configuration to specify where brew is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Add: macOS `buildkite_agent_brew_dir` to set where `brew` is installed.
+
 ## 4.0.0
 
 * Fix: Windows user password handling + doc. This was regressed within `3.3.1` during e1d9460, we're really sorry about that.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Variable names below map to [the agent configuration documentation](https://buil
 
 - `buildkite_agent_homebrew_tap_url` - You could use `git@github.com:buildkite/homebrew-buildkite.git` if you clone over ssh because you find that more reliable, but your ansible connection needs an ssh key to authenticate to github then (forwarding your ssh-agent works fine). Omitted otherwise.
 - `buildkite_agent_load_bash_profile` - Load `$HOME/.bash_profile` with buildkite agent environment hook. Ensures agent will load with bash environment.
+- `buildkite_agent_brew_dir` - Specify where `brew` is installed, `brew` uses different defaults for Intel vs. ARM processors.
 
 ### Debugging
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,27 +1,27 @@
 ---
 # core
-buildkite_agent_username: "buildkite-agent"
-buildkite_agent_user_description: "Runs BuildKite jobs. See https://buildkite.com/docs/agent/v3/."
+buildkite_agent_username: buildkite-agent
+buildkite_agent_user_description: Runs BuildKite jobs. See https://buildkite.com/docs/agent/v3/.
 buildkite_agent_conf_dir:  # https://github.com/buildkite/agent/blob/master/clicommand/agent_start.go#L100
-  Darwin: "{{ buildkite_agent_brew_dir }}/etc/buildkite-agent"
-  Debian: "/etc/buildkite-agent"
-  Windows: "c:/users/{{ buildkite_agent_username }}/AppData/Local/buildkite-agent"
+  Darwin: '{{ buildkite_agent_brew_dir }}/etc/buildkite-agent'
+  Debian: /etc/buildkite-agent
+  Windows: c:/users/{{ buildkite_agent_username }}/AppData/Local/buildkite-agent
 buildkite_agent_count: 1
-buildkite_agent_debug: "false"
+buildkite_agent_debug: 'false'
 buildkite_agent_executable:
-  Darwin: "{{ buildkite_agent_brew_dir }}/bin/buildkite-agent"
-  Debian: "/usr/bin/buildkite-agent"
-  Windows: "c:/program files/buildkite-agent/buildkite-agent.exe"
+  Darwin: '{{ buildkite_agent_brew_dir }}/bin/buildkite-agent'
+  Debian: /usr/bin/buildkite-agent
+  Windows: c:/program files/buildkite-agent/buildkite-agent.exe
 buildkite_agent_hide_secrets: true
 buildkite_agent_home_dir:
-  Darwin: "{{ buildkite_agent_brew_dir }}/var/{{ buildkite_agent_username }}"
-  Debian: "/var/lib/{{ buildkite_agent_username }}"
-  Windows: "c:/users/{{ buildkite_agent_username }}"
+  Darwin: '{{ buildkite_agent_brew_dir }}/var/{{ buildkite_agent_username }}'
+  Debian: /var/lib/{{ buildkite_agent_username }}
+  Windows: c:/users/{{ buildkite_agent_username }}
 buildkite_agent_should_install_binary:
   Darwin: yes
   Debian: yes
   Windows: yes
-buildkite_agent_token: ""
+buildkite_agent_token: ''
 # Allow the handlers to re|start service during this role.
 # If you retrieve the registration token secret via some other means, setting these
 # to false allows you to avoid service-startup errors until that's complete.
@@ -34,64 +34,64 @@ buildkite_agent_expose_secrets: false
 
 # paths config
 buildkite_agent_builds_dir:
-  Darwin: "{{ buildkite_agent_home_dir[ansible_os_family] }}/builds"
-  Debian: "{{ buildkite_agent_home_dir[ansible_os_family] }}/builds"
-  Windows: "c:/b"  # long filenames will overflow
+  Darwin: '{{ buildkite_agent_home_dir[ansible_os_family] }}/builds'
+  Debian: '{{ buildkite_agent_home_dir[ansible_os_family] }}/builds'
+  Windows: c:/b    # long filenames will overflow
 buildkite_agent_hooks_dir:
-  Darwin: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/hooks"
-  Debian: "{{ buildkite_agent_home_dir[ansible_os_family] }}/hooks"
-  Windows: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/hooks"
+  Darwin: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/hooks'
+  Debian: '{{ buildkite_agent_home_dir[ansible_os_family] }}/hooks'
+  Windows: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/hooks'
 buildkite_agent_plugins_dir:
-  Darwin: "{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins"
-  Debian: "{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins"
-  Windows: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/plugins"
+  Darwin: '{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins'
+  Debian: '{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins'
+  Windows: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/plugins'
 buildkite_agent_logs_dir:
-  Darwin: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
-  Debian: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
-  Windows: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
+  Darwin: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
+  Debian: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
+  Windows: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
 
 # configuration values, see https://buildkite.com/docs/agent/v3/configuration
 # note: the booleans are quoted otherwise they are rendered capitalised.
 buildkite_agent_bootstrap_script:
-  Darwin: "buildkite-agent bootstrap"
-  Debian: "buildkite-agent bootstrap"
-  Windows: "buildkite-agent bootstrap"
-buildkite_agent_git_clean_flags: "-fxdq"
-buildkite_agent_git_clone_flags: "-v"
-buildkite_agent_no_color: "false"
-buildkite_agent_no_command_eval: "false"
-buildkite_agent_no_plugins: "false"
-buildkite_agent_no_pty: "false"
-buildkite_agent_no_ssh_keyscan: "false"
+  Darwin: buildkite-agent bootstrap
+  Debian: buildkite-agent bootstrap
+  Windows: buildkite-agent bootstrap
+buildkite_agent_git_clean_flags: -fxdq
+buildkite_agent_git_clone_flags: -v
+buildkite_agent_no_color: 'false'
+buildkite_agent_no_command_eval: 'false'
+buildkite_agent_no_plugins: 'false'
+buildkite_agent_no_pty: 'false'
+buildkite_agent_no_ssh_keyscan: 'false'
 buildkite_agent_priority: 1
-buildkite_agent_queue: "default"
+buildkite_agent_queue: default
 buildkite_agent_start_parameters:
-  Darwin: ""
-  Debian: ""
-  Windows: "--config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
+  Darwin: ''
+  Debian: ''
+  Windows: --config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg
 buildkite_agent_start_command:
-  Darwin: "start {{ buildkite_agent_start_parameters[ansible_os_family] }}"
-  Debian: "start {{ buildkite_agent_start_parameters[ansible_os_family] }}"
-  Windows: "start { {buildkite_agent_start_parameters[ansible_os_family] }}"
+  Darwin: start {{ buildkite_agent_start_parameters[ansible_os_family] }}
+  Debian: start {{ buildkite_agent_start_parameters[ansible_os_family] }}
+  Windows: start { {buildkite_agent_start_parameters[ansible_os_family] }}
 buildkite_agent_tags: []
 buildkite_agent_tags_including_queue: "{{ ([['queue', buildkite_agent_queue] | join('=')] + buildkite_agent_tags) | join(',') }}"
-buildkite_agent_tags_from_ec2: "false"
-buildkite_agent_tags_from_ec2_tags: "false"
-buildkite_agent_tags_from_gcp: "false"
-buildkite_agent_tags_from_gcp_labels: "false"
-buildkite_agent_tags_from_host: "false"
+buildkite_agent_tags_from_ec2: 'false'
+buildkite_agent_tags_from_ec2_tags: 'false'
+buildkite_agent_tags_from_gcp: 'false'
+buildkite_agent_tags_from_gcp_labels: 'false'
+buildkite_agent_tags_from_host: 'false'
 
 # Debian options
 buildkite_agent_allow_latest: yes
-buildkite_agent_version: "3.7.0"
-buildkite_agent_build_number: "2659"
+buildkite_agent_version: 3.7.0
+buildkite_agent_build_number: '2659'
 buildkite_agent_systemd_override_template: buildkite-agent.override.conf.j2
 
 # Windows options
-buildkite_agent_nssm_exe: "C:/ProgramData/chocolatey/bin/nssm.exe"
-buildkite_agent_nssm_version: "2.24.101.20180116"
-buildkite_agent_platform: "amd64"
-buildkite_agent_windows_grant_admin: False
+buildkite_agent_nssm_exe: C:/ProgramData/chocolatey/bin/nssm.exe
+buildkite_agent_nssm_version: 2.24.101.20180116
+buildkite_agent_platform: amd64
+buildkite_agent_windows_grant_admin: false
 
 # Darwin options
 buildkite_agent_load_bash_profile: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,5 +94,5 @@ buildkite_agent_platform: 'amd64'
 buildkite_agent_windows_grant_admin: false
 
 # Darwin options
-buildkite_agent_brew_dir: /usr/local
+buildkite_agent_brew_dir: '/usr/local'
 buildkite_agent_load_bash_profile: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,18 +3,18 @@
 buildkite_agent_username: "buildkite-agent"
 buildkite_agent_user_description: "Runs BuildKite jobs. See https://buildkite.com/docs/agent/v3/."
 buildkite_agent_conf_dir:  # https://github.com/buildkite/agent/blob/master/clicommand/agent_start.go#L100
-  Darwin: "/usr/local/etc/buildkite-agent"
+  Darwin: "{{ buildkite_agent_brew_dir }}/etc/buildkite-agent"
   Debian: "/etc/buildkite-agent"
   Windows: "c:/users/{{ buildkite_agent_username }}/AppData/Local/buildkite-agent"
 buildkite_agent_count: 1
 buildkite_agent_debug: "false"
 buildkite_agent_executable:
-  Darwin: "/usr/local/bin/buildkite-agent"
+  Darwin: "{{ buildkite_agent_brew_dir }}/bin/buildkite-agent"
   Debian: "/usr/bin/buildkite-agent"
   Windows: "c:/program files/buildkite-agent/buildkite-agent.exe"
 buildkite_agent_hide_secrets: true
 buildkite_agent_home_dir:
-  Darwin: "/usr/local/var/{{ buildkite_agent_username }}"
+  Darwin: "{{ buildkite_agent_brew_dir }}/var/{{ buildkite_agent_username }}"
   Debian: "/var/lib/{{ buildkite_agent_username }}"
   Windows: "c:/users/{{ buildkite_agent_username }}"
 buildkite_agent_should_install_binary:
@@ -95,3 +95,4 @@ buildkite_agent_windows_grant_admin: False
 
 # Darwin options
 buildkite_agent_load_bash_profile: yes
+buildkite_agent_brew_dir: /usr/local

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,16 +1,16 @@
 ---
-- name: restart-systemd-buildkite
-  systemd:
-    name: "buildkite-agent"
-    state: restarted
-  when: ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]
+  - name: restart-systemd-buildkite
+    systemd:
+      name: buildkite-agent
+      state: restarted
+    when: ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]
 
-- name: restart-windows-buildkite
-  win_service:
-    name: "buildkite-agent"
-    state: restarted
-  when: ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]
+  - name: restart-windows-buildkite
+    win_service:
+      name: buildkite-agent
+      state: restarted
+    when: ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]
 
-- name: restart-darwin-buildkite
-  command: "{{ buildkite_agent_brew_dir }}/bin/brew services restart buildkite/buildkite/buildkite-agent"
-  when: ansible_os_family == "Darwin" and buildkite_agent_allow_service_startup[ansible_os_family]
+  - name: restart-darwin-buildkite
+    command: '{{ buildkite_agent_brew_dir }}/bin/brew services restart buildkite/buildkite/buildkite-agent'
+    when: ansible_os_family == "Darwin" and buildkite_agent_allow_service_startup[ansible_os_family]

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,5 +12,5 @@
   when: ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]
 
 - name: restart-darwin-buildkite
-  command: /usr/local/bin/brew services restart buildkite/buildkite/buildkite-agent
+  command: "{{ buildkite_agent_brew_dir }}/bin/brew services restart buildkite/buildkite/buildkite-agent"
   when: ansible_os_family == "Darwin" and buildkite_agent_allow_service_startup[ansible_os_family]


### PR DESCRIPTION
Since brew uses different default install locations for Intel and ARM
processors we need to be able to configure where it is installed. This
PR removes all references to the Intel default `/usr/local` and replaces
that with the new parameter.


## Changes

* Add: macOS `buildkite_agent_brew_dir` to set where `brew` is installed.

## Verification

Installed `brew` in `/opt/homebrew` and set `buildkite_agent_brew_dir` to this path then ran the playbook.
