### PR TITLE
Fix yamllint issues

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,24 +1,23 @@
 ---
 # https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
-extends: default
+extends: 'default'
 
 yaml-files:
-  - .toolsharerc
-  - .yamllint.yaml
+  - '.toolsharerc'
+  - '.yamllint.yaml'
   - '*.yaml'
   - '*.yml'
-  - OWNERS_ALIASES
-  - OWNERS
+  - 'OWNERS_ALIASES'
+  - 'OWNERS'
 
 rules:
   document-start:
-    level: error
+    level: 'error'
   indentation:
-    spaces: consistent
+    spaces: 'consistent'
     indent-sequences: true
-  key-ordering: {}
   line-length:
     max: 1200
-    level: warning
+    level: 'warning'
   quoted-strings:
-    quote-type: single
+    quote-type: 'single'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,27 +1,27 @@
 ---
 # core
-buildkite_agent_username: "buildkite-agent"
-buildkite_agent_user_description: "Runs BuildKite jobs. See https://buildkite.com/docs/agent/v3/."
+buildkite_agent_username: 'buildkite-agent'
+buildkite_agent_user_description: 'Runs BuildKite jobs. See https://buildkite.com/docs/agent/v3/.'
 buildkite_agent_conf_dir:  # https://github.com/buildkite/agent/blob/master/clicommand/agent_start.go#L100
-  Darwin: "/usr/local/etc/buildkite-agent"
-  Debian: "/etc/buildkite-agent"
-  Windows: "c:/users/{{ buildkite_agent_username }}/AppData/Local/buildkite-agent"
+  Darwin: '/usr/local/etc/buildkite-agent'
+  Debian: '/etc/buildkite-agent'
+  Windows: 'c:/users/{{ buildkite_agent_username }}/AppData/Local/buildkite-agent'
 buildkite_agent_count: 1
-buildkite_agent_debug: "false"
+buildkite_agent_debug: 'false'
 buildkite_agent_executable:
-  Darwin: "/usr/local/bin/buildkite-agent"
-  Debian: "/usr/bin/buildkite-agent"
-  Windows: "c:/program files/buildkite-agent/buildkite-agent.exe"
+  Darwin: '/usr/local/bin/buildkite-agent'
+  Debian: '/usr/bin/buildkite-agent'
+  Windows: 'c:/program files/buildkite-agent/buildkite-agent.exe'
 buildkite_agent_hide_secrets: true
 buildkite_agent_home_dir:
-  Darwin: "/usr/local/var/{{ buildkite_agent_username }}"
-  Debian: "/var/lib/{{ buildkite_agent_username }}"
-  Windows: "c:/users/{{ buildkite_agent_username }}"
+  Darwin: '/usr/local/var/{{ buildkite_agent_username }}'
+  Debian: '/var/lib/{{ buildkite_agent_username }}'
+  Windows: 'c:/users/{{ buildkite_agent_username }}'
 buildkite_agent_should_install_binary:
-  Darwin: yes
-  Debian: yes
-  Windows: yes
-buildkite_agent_token: ""
+  Darwin: true
+  Debian: true
+  Windows: true
+buildkite_agent_token: ''
 # Allow the handlers to re|start service during this role.
 # If you retrieve the registration token secret via some other means, setting these
 # to false allows you to avoid service-startup errors until that's complete.
@@ -34,64 +34,64 @@ buildkite_agent_expose_secrets: false
 
 # paths config
 buildkite_agent_builds_dir:
-  Darwin: "{{ buildkite_agent_home_dir[ansible_os_family] }}/builds"
-  Debian: "{{ buildkite_agent_home_dir[ansible_os_family] }}/builds"
-  Windows: "c:/b"  # long filenames will overflow
+  Darwin: '{{ buildkite_agent_home_dir[ansible_os_family] }}/builds'
+  Debian: '{{ buildkite_agent_home_dir[ansible_os_family] }}/builds'
+  Windows: 'c:/b'  # long filenames will overflow
 buildkite_agent_hooks_dir:
-  Darwin: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/hooks"
-  Debian: "{{ buildkite_agent_home_dir[ansible_os_family] }}/hooks"
-  Windows: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/hooks"
+  Darwin: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/hooks'
+  Debian: '{{ buildkite_agent_home_dir[ansible_os_family] }}/hooks'
+  Windows: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/hooks'
 buildkite_agent_plugins_dir:
-  Darwin: "{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins"
-  Debian: "{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins"
-  Windows: "{{ buildkite_agent_conf_dir[ansible_os_family] }}/plugins"
+  Darwin: '{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins'
+  Debian: '{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins'
+  Windows: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/plugins'
 buildkite_agent_logs_dir:
-  Darwin: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
-  Debian: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
-  Windows: "{{ buildkite_agent_conf_dir[ansible_os_family] }}"
+  Darwin: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
+  Debian: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
+  Windows: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
 
 # configuration values, see https://buildkite.com/docs/agent/v3/configuration
 # note: the booleans are quoted otherwise they are rendered capitalised.
 buildkite_agent_bootstrap_script:
-  Darwin: "buildkite-agent bootstrap"
-  Debian: "buildkite-agent bootstrap"
-  Windows: "buildkite-agent bootstrap"
-buildkite_agent_git_clean_flags: "-fxdq"
-buildkite_agent_git_clone_flags: "-v"
-buildkite_agent_no_color: "false"
-buildkite_agent_no_command_eval: "false"
-buildkite_agent_no_plugins: "false"
-buildkite_agent_no_pty: "false"
-buildkite_agent_no_ssh_keyscan: "false"
+  Darwin: 'buildkite-agent bootstrap'
+  Debian: 'buildkite-agent bootstrap'
+  Windows: 'buildkite-agent bootstrap'
+buildkite_agent_git_clean_flags: '-fxdq'
+buildkite_agent_git_clone_flags: '-v'
+buildkite_agent_no_color: 'false'
+buildkite_agent_no_command_eval: 'false'
+buildkite_agent_no_plugins: 'false'
+buildkite_agent_no_pty: 'false'
+buildkite_agent_no_ssh_keyscan: 'false'
 buildkite_agent_priority: 1
-buildkite_agent_queue: "default"
+buildkite_agent_queue: 'default'
 buildkite_agent_start_parameters:
-  Darwin: ""
-  Debian: ""
-  Windows: "--config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg"
+  Darwin: ''
+  Debian: ''
+  Windows: '--config {{ buildkite_agent_conf_dir[ansible_os_family] }}/buildkite-agent.cfg'
 buildkite_agent_start_command:
-  Darwin: "start {{ buildkite_agent_start_parameters[ansible_os_family] }}"
-  Debian: "start {{ buildkite_agent_start_parameters[ansible_os_family] }}"
-  Windows: "start { {buildkite_agent_start_parameters[ansible_os_family] }}"
+  Darwin: 'start {{ buildkite_agent_start_parameters[ansible_os_family] }}'
+  Debian: 'start {{ buildkite_agent_start_parameters[ansible_os_family] }}'
+  Windows: 'start { {buildkite_agent_start_parameters[ansible_os_family] }}'
 buildkite_agent_tags: []
-buildkite_agent_tags_including_queue: "{{ ([['queue', buildkite_agent_queue] | join('=')] + buildkite_agent_tags) | join(',') }}"
-buildkite_agent_tags_from_ec2: "false"
-buildkite_agent_tags_from_ec2_tags: "false"
-buildkite_agent_tags_from_gcp: "false"
-buildkite_agent_tags_from_gcp_labels: "false"
-buildkite_agent_tags_from_host: "false"
+buildkite_agent_tags_including_queue: '{{ ([["queue", buildkite_agent_queue] | join("=")] + buildkite_agent_tags) | join(",") }}'
+buildkite_agent_tags_from_ec2: 'false'
+buildkite_agent_tags_from_ec2_tags: 'false'
+buildkite_agent_tags_from_gcp: 'false'
+buildkite_agent_tags_from_gcp_labels: 'false'
+buildkite_agent_tags_from_host: 'false'
 
 # Debian options
-buildkite_agent_allow_latest: yes
-buildkite_agent_version: "3.7.0"
-buildkite_agent_build_number: "2659"
-buildkite_agent_systemd_override_template: buildkite-agent.override.conf.j2
+buildkite_agent_allow_latest: true
+buildkite_agent_version: '3.7.0'
+buildkite_agent_build_number: '2659'
+buildkite_agent_systemd_override_template: 'buildkite-agent.override.conf.j2'
 
 # Windows options
-buildkite_agent_nssm_exe: "C:/ProgramData/chocolatey/bin/nssm.exe"
-buildkite_agent_nssm_version: "2.24.101.20180116"
-buildkite_agent_platform: "amd64"
-buildkite_agent_windows_grant_admin: False
+buildkite_agent_nssm_exe: 'C:/ProgramData/chocolatey/bin/nssm.exe'
+buildkite_agent_nssm_version: '2.24.101.20180116'
+buildkite_agent_platform: 'amd64'
+buildkite_agent_windows_grant_admin: false
 
 # Darwin options
-buildkite_agent_load_bash_profile: yes
+buildkite_agent_load_bash_profile: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,16 +1,16 @@
 ---
-- name: restart-systemd-buildkite
-  systemd:
-    name: "buildkite-agent"
-    state: restarted
-  when: ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]
+  - name: 'restart-systemd-buildkite'  # yamllint disable-line rule:indentation
+    systemd:
+      name: 'buildkite-agent'
+      state: 'restarted'
+    when: 'ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]'
 
-- name: restart-windows-buildkite
-  win_service:
-    name: "buildkite-agent"
-    state: restarted
-  when: ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]
+  - name: 'restart-windows-buildkite'
+    win_service:
+      name: 'buildkite-agent'
+      state: 'restarted'
+    when: 'ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]'
 
-- name: restart-darwin-buildkite
-  command: /usr/local/bin/brew services restart buildkite/buildkite/buildkite-agent
-  when: ansible_os_family == "Darwin" and buildkite_agent_allow_service_startup[ansible_os_family]
+  - name: 'restart-darwin-buildkite'
+    command: '/usr/local/bin/brew services restart buildkite/buildkite/buildkite-agent'
+    when: 'ansible_os_family == "Darwin" and buildkite_agent_allow_service_startup[ansible_os_family]'


### PR DESCRIPTION
Fix the yamllint issues identified by @bombsimon in https://github.com/improbable-eng/ansible-buildkite-agent/pull/60.

This was largely changing double quotes to single quotes and 'yes' to 'true', except:

1. I disabled the `key-ordering` check in `yamllint`, because we actually _do_ want some files to use non-alpha sorted keys (eg `defaults/main.yml` is split into logical sections).
2. Added the `# yamllint disable-line rule:indentation` annotation to one file where `yamllint` and `yamlfmt` philosophically disagree on how the file ought to look, so `yamlfmt` keeps changing it back to a format that `yamllint` screams about. 🤷 