### PR TITLE
Better support for ARM/M1/Apple Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Fix: Use `brew` executable from `buildkite_agent_brew_dir` when targeting homebrew task.
+
 ## 4.1.0
 
 * Add: macOS `buildkite_agent_brew_dir` to set where `brew` is installed.

--- a/tasks/install-on-Darwin.yml
+++ b/tasks/install-on-Darwin.yml
@@ -13,6 +13,7 @@
       - name: Install buildkite-agent
         homebrew:
           name: buildkite-agent
+          path: '{{ buildkite_agent_brew_dir }}/bin'
           state: latest  # noqa 403 homebrew doesn't allow version pinning
         become: false
 


### PR DESCRIPTION
## Changes

- Support more than one installation of `brew` - don't rely on `$PATH` or defaults, use `buildkite_agent_brew_dir `.

This use case is probably not that uncommon since a lot of things still needs to be emulated/run with Rosetta 2 making you install two versions of `brew`.

## Verification

* Run the playbook on a M1 Mac with `brew` installed both in `/opt/homebrew` for arm and `/usr/local` (to support Rosetta 2/Intel installations).

---

Sorry for the messy PR. I was trying to address a bunch of issues but let's fix the linting in #65 and have this PR only address which `brew` to invoke when multiple is installed. I also created #66 to resolve the group issues I had that made this PR messy.