### PR TITLE
Improve yamllint configuration to make it less aggressive

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -18,5 +18,5 @@ rules:
     max: 1200
     level: warning
   quoted-strings:
-    quote-type: any
+    quote-type: single
     required: only-when-needed

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -13,11 +13,10 @@ yaml-files:
 rules:
   document-start:
     level: 'error'
-  indentation:
-    spaces: 'consistent'
-    indent-sequences: true
+  indentation: false
   line-length:
     max: 1200
     level: 'warning'
   quoted-strings:
-    quote-type: 'single'
+    quote-type: any
+    required: only-when-needed

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,22 +1,22 @@
 ---
 # https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
-extends: 'default'
+extends: default
 
 yaml-files:
-  - '.toolsharerc'
-  - '.yamllint.yaml'
+  - .toolsharerc
+  - .yamllint.yaml
   - '*.yaml'
   - '*.yml'
-  - 'OWNERS_ALIASES'
-  - 'OWNERS'
+  - OWNERS_ALIASES
+  - OWNERS
 
 rules:
   document-start:
-    level: 'error'
+    level: error
   indentation: false
   line-length:
     max: 1200
-    level: 'warning'
+    level: warning
   quoted-strings:
     quote-type: any
     required: only-when-needed

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-  - name: 'restart-systemd-buildkite'  # yamllint disable-line rule:indentation
+  - name: 'restart-systemd-buildkite'
     systemd:
       name: 'buildkite-agent'
       state: 'restarted'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,14 +3,14 @@
     systemd:
       name: buildkite-agent
       state: restarted
-    when: 'ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]'
+    when: ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]
 
   - name: restart-windows-buildkite
     win_service:
       name: buildkite-agent
       state: restarted'
-    when: 'ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]'
+    when: ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]
 
   - name: restart-darwin-buildkite
     command: '{{ buildkite_agent_brew_dir }}/bin/brew services restart buildkite/buildkite/buildkite-agent'
-    when: 'ansible_os_family == "Darwin" and buildkite_agent_allow_service_startup[ansible_os_family]'
+    when: ansible_os_family == "Darwin" and buildkite_agent_allow_service_startup[ansible_os_family]

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,16 +1,16 @@
 ---
-  - name: 'restart-systemd-buildkite'
+  - name: restart-systemd-buildkite
     systemd:
-      name: 'buildkite-agent'
-      state: 'restarted'
+      name: buildkite-agent
+      state: restarted
     when: 'ansible_os_family == "Debian" and buildkite_agent_allow_service_startup[ansible_os_family]'
 
-  - name: 'restart-windows-buildkite'
+  - name: restart-windows-buildkite
     win_service:
-      name: 'buildkite-agent'
-      state: 'restarted'
+      name: buildkite-agent
+      state: restarted'
     when: 'ansible_os_family == "Windows" and buildkite_agent_allow_service_startup[ansible_os_family]'
 
-  - name: 'restart-darwin-buildkite'
+  - name: restart-darwin-buildkite
     command: '{{ buildkite_agent_brew_dir }}/bin/brew services restart buildkite/buildkite/buildkite-agent'
     when: 'ansible_os_family == "Darwin" and buildkite_agent_allow_service_startup[ansible_os_family]'


### PR DESCRIPTION
This should stop yamllint from clashing with yamlfmt on indents, and reduce the unecessary quotes it asks for