### PR TITLE
Enable journal logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.2.0
+
+* Add: If `buildkite_agent_logs_dir` is unset for the target platform, log to stdout/stderr instead of an arbitrary default file.
+
 ## 4.1.0
 
 * Add: macOS `buildkite_agent_brew_dir` to set where `brew` is installed.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
   - Note: on Windows, this defaults to `c:/b` because long filenames still cause problems in the 21st Century.
 - `buildkite_agent_hooks_dir` - Path to where agent will look for hooks.
 - `buildkite_agent_plugins_dir` - Path to where agent will look for plugins.
-- `buildkite_agent_logs_dir` - Path to write agent logs.
+- `buildkite_agent_logs_dir` - Path to write agent logs - if unset, logs are printed to stdout/stderr.
   - Note that this option only applies to Windows, and Linux platforms with [systemd versions newer than late 2017](https://github.com/systemd/systemd/issues/3991).
 
 ### Configuration settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,10 +45,6 @@ buildkite_agent_plugins_dir:
   Darwin: '{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins'
   Debian: '{{ buildkite_agent_home_dir[ansible_os_family] }}/plugins'
   Windows: '{{ buildkite_agent_conf_dir[ansible_os_family] }}/plugins'
-buildkite_agent_logs_dir:
-  Darwin: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
-  Debian: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
-  Windows: '{{ buildkite_agent_conf_dir[ansible_os_family] }}'
 
 # configuration values, see https://buildkite.com/docs/agent/v3/configuration
 # note: the booleans are quoted otherwise they are rendered capitalised.

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -98,16 +98,26 @@
     with_items:
       - '{{ buildkite_agent_builds_dir[ansible_os_family] }}'
 
-  - name: configure buildkite-agent as an nssm service
+  # Only one of the below tasks will run, depending on the type of service logging
+  - name: configure buildkite-agent as an nssm service with journal-based logging
     win_nssm:
       name: buildkite-agent
       application: '{{ buildkite_agent_executable[ansible_os_family] }}'
       arguments: '{{ buildkite_agent_start_command[ansible_os_family] }}'
-      {% if buildkite_agent_logs_dir[ansible_os_family] is defined %}
       stdout_file: '{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log'
       stderr_file: '{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log'
-      {% endif %}
       executable: '{{ buildkite_agent_nssm_exe }}'
+    when: buildkite_agent_logs_dir[ansible_os_family] is undefined
+
+  - name: configure buildkite-agent as an nssm service with file-based logging
+    win_nssm:
+      name: buildkite-agent
+      application: '{{ buildkite_agent_executable[ansible_os_family] }}'
+      arguments: '{{ buildkite_agent_start_command[ansible_os_family] }}'
+      stdout_file: '{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log'
+      stderr_file: '{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log'
+      executable: '{{ buildkite_agent_nssm_exe }}'
+    when: buildkite_agent_logs_dir[ansible_os_family] is defined
 
   - name: configure service
     win_service:

--- a/tasks/install-on-Windows.yml
+++ b/tasks/install-on-Windows.yml
@@ -103,8 +103,10 @@
       name: buildkite-agent
       application: '{{ buildkite_agent_executable[ansible_os_family] }}'
       arguments: '{{ buildkite_agent_start_command[ansible_os_family] }}'
+      {% if buildkite_agent_logs_dir[ansible_os_family] is defined %}
       stdout_file: '{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log'
       stderr_file: '{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log'
+      {% endif %}
       executable: '{{ buildkite_agent_nssm_exe }}'
 
   - name: configure service

--- a/templates/buildkite-agent.override.conf.j2
+++ b/templates/buildkite-agent.override.conf.j2
@@ -8,7 +8,8 @@ ExecStart={{ buildkite_agent_executable[ansible_os_family] }} {{ buildkite_agent
 
 User={{ buildkite_agent_username }}
 
-# These options will only work on systemd newer than late 2017 (https://github.com/systemd/systemd/issues/3991)
-# On older systemd, they will generate a warning, but no error.
-StandardOutput=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log
-StandardError=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log
+# Only point the agent logs at files if the log dir var is set. Otherwise they will flow to stdout/stderr/journal.
+{% if buildkite_agent_logs_dir[ansible_os_family] is defined %}
+  StandardOutput=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log
+  StandardError=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log
+{% endif %}

--- a/templates/buildkite-agent.override.conf.j2
+++ b/templates/buildkite-agent.override.conf.j2
@@ -8,8 +8,8 @@ ExecStart={{ buildkite_agent_executable[ansible_os_family] }} {{ buildkite_agent
 
 User={{ buildkite_agent_username }}
 
-# Only point the agent logs at files if the log dir var is set. Otherwise they will flow to stdout/stderr/journal.
 {% if buildkite_agent_logs_dir[ansible_os_family] is defined %}
+  # Point the agent logs at files if the user chooses a log dir. Otherwise they will flow to stdout/stderr/journal.
   StandardOutput=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log
   StandardError=file:{{ buildkite_agent_logs_dir[ansible_os_family] }}/buildkite-agent.log
 {% endif %}


### PR DESCRIPTION
Set the default behavior back to stream/journal-based logging If the user doesn't pass in a file-based log location via `buildkite_agent_logs_dir`.

## Changes

When I added the ability to use file-based systemd logs [in this PR](https://github.com/improbable-eng/ansible-buildkite-agent/pull/35), I removed the ability to do journal-based/stdout logging. This is a capability that we need back now, due to an unrelated infrastructure change. Whoops.

## Verification

TBD - I'll apply this change on both Windows and Linux to confirm before merging.
