### PR TITLE
Add support to configure name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Add: `buildkite_agent_name` option.
 * Fix: Use `brew` executable from `buildkite_agent_brew_dir` when targeting homebrew task.
 
 ## 4.2.0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An Ansible role to install the [Buildkite Agent](https://buildkite.com/docs/agen
 - `buildkite_agent_start_parameters` - Command line flags to pass to the `buildkite-agent start` command to start the agent.
 - `buildkite_agent_start_command` - Arguments passed verbatim to the `buildkite_agent_executable` at startup.  Wraps `buildkite_agent_start_parameters` by default - if using a shim or script for `buildkite_agent_executable`, override this instead of `buildkite_agent_start_parameters`.
 - `buildkite_agent_token` - Buildkite agent registration token. Available from `https://buildkite.com/organizations/{org-slug}/agents`.
+- `buildkite_agent_name` - Name for the Buildkite agent(s).
 
 ### Paths-related
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ buildkite_agent_should_install_binary:
   Darwin: true
   Debian: true
   Windows: true
+buildkite_agent_name: '%hostname-%n'
 buildkite_agent_token: ''
 # Allow the handlers to re|start service during this role.
 # If you retrieve the registration token secret via some other means, setting these

--- a/templates/buildkite-agent.cfg.j2
+++ b/templates/buildkite-agent.cfg.j2
@@ -2,7 +2,7 @@
 token="{{ buildkite_agent_token }}"
 
 # The name of the agent
-name="%hostname-%n"
+name="{{ buildkite_agent_name }}"
 
 # Number of agents to spawn
 spawn="{{ buildkite_agent_count | default('1') }}"


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

* Add: `buildkite_agent_name` option.

## Verification

Ran the playbook, confirmed the configuration had the value set in my settings.