### PR TITLE
Use %spawn to interpolate agent_name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ buildkite_agent_should_install_binary:
   Darwin: true
   Debian: true
   Windows: true
-buildkite_agent_name: '%hostname-%n'
+buildkite_agent_name: '%hostname-%spawn'
 buildkite_agent_token: ''
 # Allow the handlers to re|start service during this role.
 # If you retrieve the registration token secret via some other means, setting these

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,8 +80,8 @@ buildkite_agent_tags_from_host: 'false'
 
 # Debian options
 buildkite_agent_allow_latest: true
-buildkite_agent_version: 3.7.0
-buildkite_agent_build_number: '2659'
+buildkite_agent_version: 3.36.1
+buildkite_agent_build_number: '4331'
 buildkite_agent_systemd_override_template: buildkite-agent.override.conf.j2
 
 # Windows options


### PR DESCRIPTION
## Changes

This changes the agent name value to use `%spawn` to add a per-agent index to the agent name, instead of `%n`.

According to the BK folks, this is faster and more reliable, because the interpolation is client-side instead of server-side, and they intend to eventually (not soon, but eventually) deprecate and remove the `%n` feature in favor of just `%spawn`. Might as well get out in front of that.

Functionally speaking, this should behave exactly the same as the current interpolation, with a potential positive change to agent registration time (and decreased scaling load on the BK orchestration server).

It incidentally also updates the default buildkite-agent version to the current latest (`v3.36.1`), because the `%spawn` syntax was added in `buildkite-agent` `v3.27.0`. The agent version to be installed can still be overridden by ansible. 

With this change, the behavior of this role with an agent version older than `v3.27.0` is undefined, but I expect that it will not be compatible. I will update this PR shortly to add a compatibility note to the docs, and bump the major version of the role.

See [this announcement post](https://buildkite.com/changelog/155-agent-names-no-longer-support-percent-n), and for those with access, [Slack thread with context](https://improbable.slack.com/archives/CB4GZ2WAU/p1655298387602929).

## Verification

We currently install `v3.33.3` in all of our internal usages of this role, so I will validate that `v3.36.1` still works, and that installed agents register successfully with both `agent_count=1` and `agent_count>1`, but I don't currently anticipate any issues.
