### PR TITLE
Debian: systemd enabled only if service startup is allowed

### DIFF
--- a/tasks/install-on-Debian.yml
+++ b/tasks/install-on-Debian.yml
@@ -72,5 +72,5 @@
     systemd:
       name: buildkite-agent
       state: '{{ buildkite_agent_allow_service_startup[ansible_os_family] | ternary(''started'', ''stopped'') }}'
-      enabled: true
+      enabled: '{{ buildkite_agent_allow_service_startup[ansible_os_family] }}'
       daemon_reload: true


### PR DESCRIPTION
`buildkite_agent_allow_service_startup` controls whether service should be started or not, but in case of `Debian` service is enabled in systemd, which leads to auto starts on reboots. Using same variable to control the systemd enable/disable as well.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
Using `buildkite_agent_allow_service_startup` to control the `enabled` parameter of `systemd` unit for Debian systems.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
`ansible-playbook .... --check`